### PR TITLE
Add Contact Us Link to Email

### DIFF
--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -22,7 +22,7 @@ export default function Home() {
           </p>
           <div className="cta-buttons">
             <Link href="/careers" className="primary-button" >Join Us</Link>
-            <Link href="/sponsors#contact-us" className="secondary-button">Contact Us</Link>
+            <Link href="mailto:utorontomist@gmail.com" className="secondary-button">Contact Us</Link>
           </div>
         </div>
         <div className="cta-logo">


### PR DESCRIPTION
This pull request includes a small change to the `client/src/app/page.tsx` file. The change updates the "Contact Us" button to use a mailto link (`mailto:utorontomist@gmail.com`) instead of linking to the `/sponsors#contact-us` section.