### PR TITLE
[FEATURE][READY-FOR-REVIEW] -  Add a Calendar to the Events Page

### DIFF
--- a/client/src/app/events/page.tsx
+++ b/client/src/app/events/page.tsx
@@ -131,7 +131,7 @@ export default function EventsPage() {
         </p>
         <div className="w-full max-w-4xl mx-auto my-6 rounded-lg overflow-hidden shadow-lg aspect-[3/4] sm:aspect-[3/2]">
           <iframe 
-            src="https://calendar.google.com/calendar/embed?src=7000a4997a47b7e3b0a6a6b7f84452ba11881802fe62ec2c0adf6cfc28cf2cd8%40group.calendar.google.com&ctz=America%2FNew_York" 
+            src="https://calendar.google.com/calendar/embed?src=51eeb2795ecb293d64557f280d8114d38b73dffda4c188d63aa65d41f2a7286f%40group.calendar.google.com&ctz=America%2FToronto" 
             style={{ border: 0 }} 
             className="w-full h-full"
             frameBorder="0" 

--- a/client/src/app/events/page.tsx
+++ b/client/src/app/events/page.tsx
@@ -126,9 +126,18 @@ export default function EventsPage() {
       {/* Hero section - Main title and subtitle */}
       <div className="hero-section">
         <h2 className="hero-title text-3xl sm:text-4xl">Events</h2>
-        <p className="hero-subtitle text-sm sm:text-base px-2 sm:px-15">
+        <p className="text-sm sm:text-base px-2 sm:px-15">
           See what is happening in our UTMIST community
         </p>
+        <div className="w-full max-w-4xl mx-auto my-6 rounded-lg overflow-hidden shadow-lg aspect-[3/4] sm:aspect-[3/2]">
+          <iframe 
+            src="https://calendar.google.com/calendar/embed?src=7000a4997a47b7e3b0a6a6b7f84452ba11881802fe62ec2c0adf6cfc28cf2cd8%40group.calendar.google.com&ctz=America%2FNew_York" 
+            style={{ border: 0 }} 
+            className="w-full h-full"
+            frameBorder="0" 
+            scrolling="no"
+          />
+        </div>
       </div>
 
       {/* Upcoming events section with search and filtering */}

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -38,9 +38,9 @@ export default function RootLayout({
       <body
         className={`${roboto.variable} ${spaceGrotesk.variable} antialiased`}
       >
-        {/* <Navbar/> */}
+        <Navbar/>
         {children}
-        {/* <Footer/> */}
+        <Footer/>
       </body>
     </html>
   );

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -38,9 +38,9 @@ export default function RootLayout({
       <body
         className={`${roboto.variable} ${spaceGrotesk.variable} antialiased`}
       >
-        <Navbar/>
+        {/* <Navbar/> */}
         {children}
-        <Footer/>
+        {/* <Footer/> */}
       </body>
     </html>
   );


### PR DESCRIPTION
📖 Description

This pull request adds the new UTMIST Calendar component to the Events page, enabling users to view upcoming UTMIST-organized events in a clean, month-at-a-glance calendar layout.

This pull request references Issue #41.

✅ Objectives

- [ ] Embed an interactive month-at-a-glance calendar on the Events page to replace the linear feed view.
- [ ] Ensure responsive layouts across mobile, tablet, and desktop breakpoints.
- [ ] Align with existing design system and UX mockups for visual consistency.
🎯 Acceptance Criteria

The calendar component displays the current month in a month-at-a-glance grid when the Events page loads.
Clicking the “‹” or “›” arrows updates the grid to the previous or next month, respectively, without a full page reload.
Appropriate tests are provided and all test cases are passing

Notes:
- The user has to be logged into their Google account to be able to see the calendar.
- "Events from one or more calendars could not be shown here because you do not have the permission to view them.
" - This appears, It seems like there needs to be public permissions set for the respective Google Calendar.