### PR TITLE
Delete .next directory

### DIFF
--- a/.next/trace
+++ b/.next/trace
@@ -1,5 +1,0 @@
-[{"name":"next-dev","duration":588639,"timestamp":19082035286,"id":1,"tags":{},"startTime":1748738935796,"traceId":"64e8e28919cb1961"}]
-[{"name":"next-dev","duration":636305,"timestamp":150677334,"id":1,"tags":{},"startTime":1748806109208,"traceId":"fe51e177cd6f77e3"}]
-[{"name":"next-dev","duration":608254,"timestamp":636092350,"id":1,"tags":{},"startTime":1749073013116,"traceId":"9ccd0d33db1c16d1"}]
-[{"name":"next-dev","duration":619940,"timestamp":34907249,"id":1,"tags":{},"startTime":1749083662705,"traceId":"da365ec5dbb5a5f4"}]
-[{"name":"next-dev","duration":678466,"timestamp":1087389321,"id":1,"tags":{},"startTime":1749154017738,"traceId":"567f1ca035341c3c"}]


### PR DESCRIPTION
This pull request removes outdated trace data from the `.next/trace` file to clean up the repository.

* [`.next/trace`](diffhunk://#diff-b261b4b6757c732c7bd1be0117dc749eb52cfb4545754b88c2514c79d9ae8e69L1-L5): Deleted several entries of old trace data