### PR TITLE
Issue 77 - Made speakers on eigenai page be in 2 columns, and fixed spacing issue with the title on the eigenai page

### DIFF
--- a/client/src/app/eigenai/page.tsx
+++ b/client/src/app/eigenai/page.tsx
@@ -10,7 +10,7 @@ import BasisVectors from "@/components/basisvectors";
 
 export default function EigenAIPage() {
   return (
-    <main className="sm: items-start sm: justify-center">
+    <main className="pt-24 sm:items-start sm:justify-center">
       <div className="hero-section px-4 md:px-8">
         <h2 className="hero-title text-4xl md:text-5xl lg:text-6xl">EigenAI</h2>
         <p className="hero-subtitle text-sm md:text-base px-4 md:px-8 lg:px-16">

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -6,10 +6,10 @@ import { Roboto, Space_Grotesk } from "next/font/google";
 
 // Importing fonts from Google Fonts
 const roboto = Roboto({
-  weight: ['300', '400', '500', '700'],  // Added specific weights
+  weight: ["300", "400", "500", "700"], // Added specific weights
   variable: "--font-roboto",
   subsets: ["latin"],
-  display: 'swap',
+  display: "swap",
 });
 
 const spaceGrotesk = Space_Grotesk({
@@ -35,12 +35,19 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <script
+          defer
+          src="https://cloud.umami.is/script.js"
+          data-website-id="b8823fc7-2a15-4942-af06-bf179b7fac1a"
+        ></script>
+      </head>
       <body
         className={`${roboto.variable} ${spaceGrotesk.variable} antialiased`}
       >
-        <Navbar/>
+        <Navbar />
         {children}
-        <Footer/>
+        <Footer />
       </body>
     </html>
   );

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -35,13 +35,6 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <head>
-        <script
-          defer
-          src="https://cloud.umami.is/script.js"
-          data-website-id="b8823fc7-2a15-4942-af06-bf179b7fac1a"
-        ></script>
-      </head>
       <body
         className={`${roboto.variable} ${spaceGrotesk.variable} antialiased`}
       >

--- a/client/src/components/speakers.tsx
+++ b/client/src/components/speakers.tsx
@@ -14,56 +14,32 @@ interface Props {
 }
 
 export default function SpeakersGrid({ speakers }: Props) {
-  const firstRow = speakers.slice(0, 3);
-  const secondRow = speakers.slice(3, 7);
-
   return (
-    <div className="speakers-container">
-      <h2 className="speakers-title">Our Past Speakers</h2>
+    <div className="speakers-container px-4">
+      <h2 className="speakers-title mb-4 text-2xl md:text-3xl font-semibold">
+        Our Past Speakers
+      </h2>
 
-      <div className="speakers-row">
-        {firstRow.map((s, i) => (
+      <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {speakers.map((s, i) => (
           <a
-            key={`row1-${i}`}
+            key={i}
             href={s.profileURL}
-            className="speaker-card"
+            className="border rounded-lg p-4 bg-white shadow hover:shadow-md transition"
             target="_blank"
             rel="noopener noreferrer"
           >
-            <Image
-              src={s.profileImage}
-              alt={`${s.name}'s profile picture`}
-              width={100}
-              height={100}
-              className="speaker-photo object-cover"
-            />
-            <div className="speaker-info">
-              <p className="speaker-name">{s.name}</p>
-              <p className="speaker-role">{s.role}</p>
-            </div>
-          </a>
-        ))}
-      </div>
+            <div className="flex flex-col items-center text-center">
+              <Image
+                src={s.profileImage}
+                alt={`${s.name}'s profile picture`}
+                width={100}
+                height={100}
+                className="w-24 h-24 rounded-full object-cover mb-2"
+              />
 
-      <div className="speakers-row">
-        {secondRow.map((s, i) => (
-          <a
-            key={`row2-${i}`}
-            href={s.profileURL}
-            className="speaker-card"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              src={s.profileImage}
-              alt={`${s.name}'s profile picture`}
-              width={100}
-              height={100}
-              className="speaker-photo object-cover"
-            />
-            <div className="speaker-info">
-              <p className="speaker-name">{s.name}</p>
-              <p className="speaker-role">{s.role}</p>
+              <p className="font-medium">{s.name}</p>
+              <p className="text-sm text-gray-600">{s.role}</p>
             </div>
           </a>
         ))}

--- a/client/src/components/speakers.tsx
+++ b/client/src/components/speakers.tsx
@@ -22,12 +22,9 @@ export default function SpeakersGrid({ speakers }: Props) {
 
       <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
         {speakers.map((s, i) => (
-          <a
+          <div
             key={i}
-            href={s.profileURL}
             className="border rounded-lg p-4 bg-white shadow hover:shadow-md transition"
-            target="_blank"
-            rel="noopener noreferrer"
           >
             <div className="flex flex-col items-center text-center">
               <Image
@@ -35,13 +32,14 @@ export default function SpeakersGrid({ speakers }: Props) {
                 alt={`${s.name}'s profile picture`}
                 width={100}
                 height={100}
+                draggable={false}
                 className="w-24 h-24 rounded-full object-cover mb-2"
               />
 
               <p className="font-medium">{s.name}</p>
               <p className="text-sm text-gray-600">{s.role}</p>
             </div>
-          </a>
+          </div>
         ))}
       </div>
     </div>


### PR DESCRIPTION
Fixed issue 77, the speakers are now in a 2 column grid. 
Also fixed issue 78, the title of the eigenai page was too far up and was obscured by the navbar, so I fixed that too.
![image](https://github.com/user-attachments/assets/b02a30e3-ccd3-4998-86dc-01a2bc847a01)
![image](https://github.com/user-attachments/assets/15faff27-dce2-4504-bed9-6e80fbea7068)

