### PR TITLE
[FEATURE]: Add  A Sign Out Button to the Profile Page

### DIFF
--- a/client/src/app/profile/page.tsx
+++ b/client/src/app/profile/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { getCurrentUser } from "@/utils/auth";
+import { getCurrentUser, logout } from "@/utils/auth";
 import { getCurrentUserProfile } from "@/utils/user";
 import type { UserProfile, AuthUser } from "@/types/auth";
 import ProfileCard from "@/components/profile/ProfileCard";
@@ -76,6 +76,15 @@ export default function ProfilePage() {
     }
   };
 
+  const handleLogout = async () => {
+    try {
+      await logout();
+      router.push('/auth');
+    } catch (error) {
+      console.error('Error logging out:', error);
+    }
+  };
+
   // Show loading state
   if (loading) {
     return (
@@ -140,6 +149,7 @@ export default function ProfilePage() {
             <ProfileCard
               userProfile={profile}
               onEdit={handleEditProfile}
+              onLogout={handleLogout}
               isEditing={isEditing}
             />
           )}

--- a/client/src/app/profile/page.tsx
+++ b/client/src/app/profile/page.tsx
@@ -79,7 +79,7 @@ export default function ProfilePage() {
   const handleLogout = async () => {
     try {
       await logout();
-      router.push('/auth');
+      router.push('/');
     } catch (error) {
       console.error('Error logging out:', error);
     }

--- a/client/src/components/profile/ProfileCard.tsx
+++ b/client/src/components/profile/ProfileCard.tsx
@@ -73,8 +73,7 @@ export default function ProfileCard({
           {onLogout && (
             <button
               onClick={onLogout}
-              style={{ background: "var(--gradient-b2)" }}
-              className="px-6 py-2 rounded-lg font-[var(--system-font)] text-white hover:opacity-90 hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--secondary)] transition-all duration-200"
+              className="bg-gradient-to-r from-red-600 to-red-400 px-6 py-2 rounded-lg font-[var(--system-font)] text-white hover:opacity-90 hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--secondary)] transition-all duration-200"
             >
               Sign Out
             </button>

--- a/client/src/components/profile/ProfileCard.tsx
+++ b/client/src/components/profile/ProfileCard.tsx
@@ -7,12 +7,14 @@ import type { UserProfile } from "@/types/auth";
 interface ProfileCardProps {
   userProfile: UserProfile;
   onEdit?: () => void;
+  onLogout?: () => void;
   isEditing?: boolean;
 }
 
 export default function ProfileCard({
   userProfile,
   onEdit,
+  onLogout,
   isEditing = false,
 }: ProfileCardProps) {
   const defaultBio = "please update your bio";
@@ -66,6 +68,15 @@ export default function ProfileCard({
               }`}
             >
               {isEditing ? "Editing..." : "Edit Profile"}
+            </button>
+          )}
+          {onLogout && (
+            <button
+              onClick={onLogout}
+              style={{ background: "var(--gradient-b2)" }}
+              className="px-6 py-2 rounded-lg font-[var(--system-font)] text-white hover:opacity-90 hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--secondary)] transition-all duration-200"
+            >
+              Sign Out
             </button>
           )}
         </div>


### PR DESCRIPTION
## Description
This PR introduces a **Sign Out button** to the Profile Page to improve usability. Previously, users could not sign out directly from their profile, which reduced user control and could cause confusion.

## Changes
- Added a **Sign Out button** beside the existing **Edit Profile** button.  
- When clicked, the Sign Out button logs the user out and redirects them to the Home Page.  
- Placement decision: button was added next to *Edit Profile* for visibility and consistency.  
  - If you feel a different location would work better, please feel free to reach out and suggest alternatives (I feel like placing it there is better than at the bottom of the profile page but let me know otherwise)

## Benefits
- Improves user experience by making sign-out quick and easy to find.  
- Follows common design conventions by placing sign-out in a prominent, predictable location.

## Alternatives Considered
- Relying on session expiry (less secure, no user control).

## Estimated Effort
~1 day
