### PR TITLE
test: add unit tests for all client pages

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -11,6 +11,9 @@ const config = {
   coverageProvider: 'v8',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
   testMatch: [
     '<rootDir>/tests/**/*.(test|spec).(js|jsx|ts|tsx)'
   ],

--- a/client/tests/unit/pages/admin.test.tsx
+++ b/client/tests/unit/pages/admin.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+
+const mockRedirect = jest.fn((path: string) => {
+  throw new Error(`__REDIRECT__:${path}`);
+});
+
+jest.mock('next/navigation', () => ({
+  redirect: (path: string) => mockRedirect(path),
+}));
+
+const mockGetUser = jest.fn();
+const mockSingle = jest.fn();
+const mockEq = jest.fn(() => ({ single: mockSingle }));
+const mockSelect = jest.fn(() => ({ eq: mockEq }));
+const mockFrom = jest.fn(() => ({ select: mockSelect }));
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(async () => ({
+    auth: { getUser: () => mockGetUser() },
+    from: mockFrom,
+  })),
+}));
+
+jest.mock('@/app/admin/AdminPageClient', () => ({
+  __esModule: true,
+  default: () => <div data-testid="admin-client">Admin Client</div>,
+}));
+
+jest.mock('@/app/admin/AddCalendly', () => ({
+  __esModule: true,
+  default: ({ userId, calendly }: { userId: string; calendly: string }) => (
+    <div data-testid="add-calendly">
+      {userId}-{calendly}
+    </div>
+  ),
+}));
+
+import AdminPage from '@/app/admin/page';
+
+describe('Admin Page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redirects to /auth when there is no logged-in user', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    await expect(AdminPage()).rejects.toThrow('__REDIRECT__:/auth');
+    expect(mockRedirect).toHaveBeenCalledWith('/auth');
+  });
+
+  it('redirects to /auth when the user is not an admin', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockSingle.mockResolvedValue({ data: { id: 'u1', admin: false }, error: null });
+    await expect(AdminPage()).rejects.toThrow('__REDIRECT__:/auth');
+  });
+
+  it('redirects when the database query returns an error', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockSingle.mockResolvedValue({ data: null, error: { message: 'fail' } });
+    await expect(AdminPage()).rejects.toThrow('__REDIRECT__:/auth');
+  });
+
+  it('renders the admin client and calendly form for admin users', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockSingle.mockResolvedValue({
+      data: { id: 'u1', admin: true, calendly: 'https://calendly.com/me' },
+      error: null,
+    });
+
+    const node = await AdminPage();
+    render(node);
+
+    expect(screen.getByTestId('admin-client')).toBeInTheDocument();
+    expect(screen.getByTestId('add-calendly')).toHaveTextContent(
+      'u1-https://calendly.com/me'
+    );
+  });
+
+  it('passes an empty calendly string when one is not present in the user row', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u2' } } });
+    mockSingle.mockResolvedValue({
+      data: { id: 'u2', admin: true, calendly: null },
+      error: null,
+    });
+
+    const node = await AdminPage();
+    render(node);
+
+    expect(screen.getByTestId('add-calendly')).toHaveTextContent('u2-');
+  });
+});

--- a/client/tests/unit/pages/ai2.test.tsx
+++ b/client/tests/unit/pages/ai2.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+jest.mock('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: 'light' }),
+}));
+
+jest.mock('react-chrono', () => ({
+  Chrono: ({ items }: { items: Array<{ title?: string; cardTitle?: string }> }) => (
+    <div data-testid="chrono">
+      {items.map((item, i) => (
+        <div key={i}>{item.cardTitle || item.title}</div>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock('@/components/cards/ai2-new-feature-card', () => ({
+  AI2Card: ({ title }: { title: string }) => <div data-testid="ai2-card">{title}</div>,
+}));
+
+jest.mock('@/components/peopleGrid', () => ({
+  __esModule: true,
+  default: ({ people }: { people: Array<{ name: string }> }) => (
+    <div data-testid="people-grid">{people.length}</div>
+  ),
+}));
+
+jest.mock('@/app/ai2/data', () => ({
+  specialThanks: [{ name: 'Past Organizer' }],
+  aiSquaredDetails: [
+    { image: '/cube.png', title: 'Step 1', text: 'Sign up' },
+    { image: '/cube.png', title: 'Step 2', text: 'Build agent' },
+  ],
+  newFeatures: [
+    { title: 'Feature A', desc: 'Description A', img: '/a.png' },
+    { title: 'Feature B', desc: 'Description B', img: '/b.png' },
+  ],
+  kickOff: [{ title: 'Kickoff Event', cardTitle: 'Kickoff Card' }],
+  finalsBracket: [{ title: 'Finals', cardTitle: 'Finals Card' }],
+  agentDevelopment: [{ title: 'Dev', cardTitle: 'Development Card' }],
+  ai2Logo: '/ai2.png',
+  sponsorsLogos: [
+    { name: 'Sponsor1', tier: 'Gold', image: '/s1.png', url: 'https://s1.com' },
+  ],
+  ai2speakers: [
+    { name: 'Speaker 1' },
+    { name: 'Speaker 2' },
+    { name: 'Speaker 3' },
+    { name: 'Speaker 4' },
+  ],
+  panelSpeakers: [{ name: 'Panel Speaker' }],
+}));
+
+import AI2Page from '@/app/ai2/page';
+
+describe('AI2 Page', () => {
+  it('renders hero title and apply button', () => {
+    render(<AI2Page />);
+    expect(
+      screen.getByRole('heading', { level: 1, name: /^AI Squared$/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Apply!/i })).toBeInTheDocument();
+  });
+
+  it('renders the How it Works steps', () => {
+    render(<AI2Page />);
+    expect(screen.getByText('Step 1')).toBeInTheDocument();
+    expect(screen.getByText('Step 2')).toBeInTheDocument();
+  });
+
+  it('renders the new feature cards', () => {
+    render(<AI2Page />);
+    const cards = screen.getAllByTestId('ai2-card');
+    expect(cards).toHaveLength(2);
+    expect(screen.getByText('Feature A')).toBeInTheDocument();
+    expect(screen.getByText('Feature B')).toBeInTheDocument();
+  });
+
+  it('defaults to the November 2 (Expo) timeline tab', () => {
+    render(<AI2Page />);
+    expect(screen.getByText('Expo')).toBeInTheDocument();
+  });
+
+  it('switches the timeline when a different date button is clicked', () => {
+    render(<AI2Page />);
+    fireEvent.click(screen.getByRole('button', { name: 'October 25' }));
+    expect(screen.getByText('Kickoff')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'October 25 - November 1' }));
+    expect(screen.getByText('Agent Development')).toBeInTheDocument();
+  });
+
+  it('renders sponsors and speakers sections', () => {
+    render(<AI2Page />);
+    expect(screen.getByText('Sponsor1')).toBeInTheDocument();
+    expect(screen.getByText(/Speakers Session/i)).toBeInTheDocument();
+    expect(screen.getByText(/Panel Speakers/i)).toBeInTheDocument();
+  });
+});

--- a/client/tests/unit/pages/applicants-profile.test.tsx
+++ b/client/tests/unit/pages/applicants-profile.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const mockUseParams = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useParams: () => mockUseParams(),
+}));
+
+jest.mock('@/assets/applicants.json', () => [
+  {
+    id: 'a1',
+    name: 'Ada Lovelace',
+    role: 'ML Engineer',
+    interviewStatus: 'Pending',
+    applicationStatus: 'Pending',
+    email: 'ada@test.com',
+    phone: '416-000-0000',
+    school: 'UofT',
+    major: 'CS',
+    year: '3',
+  },
+  {
+    id: 'a2',
+    name: 'Bob Smith',
+    role: 'Researcher',
+    interviewStatus: 'Scheduled',
+    applicationStatus: 'Waitlisted',
+    email: 'bob@test.com',
+    phone: '416-111-1111',
+    school: 'York',
+    major: 'Math',
+    year: '4',
+  },
+]);
+
+import ApplicantProfile from '@/app/applicants/[profile]/page';
+
+describe('Applicant Profile Page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the applicant\'s details when the id matches', () => {
+    mockUseParams.mockReturnValue({ profile: 'a1' });
+    render(<ApplicantProfile />);
+
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+    expect(screen.getByText('ML Engineer')).toBeInTheDocument();
+    expect(screen.getByText(/Interview Status: Pending/i)).toBeInTheDocument();
+    expect(screen.getByText(/Application Status: Pending/i)).toBeInTheDocument();
+    expect(screen.getByText('ada@test.com')).toBeInTheDocument();
+  });
+
+  it('shows a "not found" state when the id does not match any applicant', () => {
+    mockUseParams.mockReturnValue({ profile: 'does-not-exist' });
+    render(<ApplicantProfile />);
+    expect(screen.getByText(/applicant not found/i)).toBeInTheDocument();
+  });
+
+  it('hides the schedule interview button once the interview is scheduled', () => {
+    mockUseParams.mockReturnValue({ profile: 'a2' });
+    render(<ApplicantProfile />);
+    expect(
+      screen.queryByRole('button', { name: /schedule interview/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('updates the notes field when typed into', () => {
+    mockUseParams.mockReturnValue({ profile: 'a1' });
+    render(<ApplicantProfile />);
+
+    const textarea = screen.getByPlaceholderText(/type your notes here/i) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'Strong candidate' } });
+    expect(textarea.value).toBe('Strong candidate');
+  });
+
+  it('renders the Back link to /applicants', () => {
+    mockUseParams.mockReturnValue({ profile: 'a1' });
+    render(<ApplicantProfile />);
+    expect(screen.getByRole('link', { name: /back/i })).toHaveAttribute('href', '/applicants');
+  });
+});

--- a/client/tests/unit/pages/applicants.test.tsx
+++ b/client/tests/unit/pages/applicants.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+jest.mock('@/components/admin/ApplicantRow', () => ({
+  __esModule: true,
+  default: ({ applicant }: { applicant: { id: string; name: string } }) => (
+    <tr data-testid="applicant-row">
+      <td>{applicant.name}</td>
+    </tr>
+  ),
+}));
+
+import ApplicantsDashboard from '@/app/applicants/page';
+
+describe('Applicants Dashboard Page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the empty state when the API returns no applications', async () => {
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ applications: [], totalPages: 1, page: 1 }),
+    });
+
+    render(<ApplicantsDashboard />);
+    expect(await screen.findByText(/no applications found/i)).toBeInTheDocument();
+  });
+
+  it('renders applicant rows for each result returned', async () => {
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        applications: [
+          { id: '1', name: 'Alice', interviewStatus: 'Pending' },
+          { id: '2', name: 'Bob', interviewStatus: 'Scheduled' },
+        ],
+        totalPages: 1,
+        page: 1,
+      }),
+    });
+
+    render(<ApplicantsDashboard />);
+    await waitFor(() => expect(screen.getAllByTestId('applicant-row')).toHaveLength(2));
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('passes name and role search params to the API on Apply Filters', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ applications: [], totalPages: 1, page: 1 }),
+    });
+    (global.fetch as jest.Mock) = fetchMock;
+
+    render(<ApplicantsDashboard />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText(/search name/i), { target: { value: 'Alice' } });
+    fireEvent.change(screen.getByLabelText(/search role/i), { target: { value: 'Dev' } });
+    fireEvent.click(screen.getByRole('button', { name: /apply filters/i }));
+
+    await waitFor(() => {
+      const lastCall = fetchMock.mock.calls.at(-1)?.[0] as string;
+      expect(lastCall).toContain('name=Alice');
+      expect(lastCall).toContain('role=Dev');
+    });
+  });
+
+  it('shows an error message when the API request fails', async () => {
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({ ok: false, status: 500 });
+    render(<ApplicantsDashboard />);
+    expect(await screen.findByText(/api error: 500/i)).toBeInTheDocument();
+  });
+
+  it('disables the Previous button on the first page', async () => {
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ applications: [], totalPages: 3, page: 1 }),
+    });
+    render(<ApplicantsDashboard />);
+
+    const prev = await screen.findByRole('button', { name: /previous/i });
+    expect(prev).toBeDisabled();
+  });
+});

--- a/client/tests/unit/pages/apply.test.tsx
+++ b/client/tests/unit/pages/apply.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+jest.mock('@/utils/validation', () => ({
+  validatePhoneNumber: jest.fn(() => true),
+  validatePostalCode: jest.fn(() => true),
+}));
+
+import ApplicationForm from '@/app/apply/page';
+
+describe('Apply Page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (global.fetch as jest.Mock).mockReset?.();
+    global.alert = jest.fn();
+  });
+
+  it('renders all form sections', () => {
+    render(<ApplicationForm />);
+    expect(screen.getByRole('heading', { name: /apply here/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /personal information/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /contact information/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /^education$/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /why join UTMIST/i })).toBeInTheDocument();
+    expect(screen.getByText(/Resume Upload/i)).toBeInTheDocument();
+  });
+
+  it('updates first and last name fields when typed into', () => {
+    render(<ApplicationForm />);
+    const first = screen.getByLabelText(/first name/i) as HTMLInputElement;
+    const last = screen.getByLabelText(/last name/i) as HTMLInputElement;
+
+    fireEvent.change(first, { target: { value: 'Ada' } });
+    fireEvent.change(last, { target: { value: 'Lovelace' } });
+
+    expect(first.value).toBe('Ada');
+    expect(last.value).toBe('Lovelace');
+  });
+
+  it('formats the phone number as the user types', () => {
+    const { container } = render(<ApplicationForm />);
+    const phone = container.querySelector('#phoneNumber') as HTMLInputElement;
+    expect(phone).not.toBeNull();
+
+    fireEvent.change(phone, { target: { value: '4165550123' } });
+    expect(phone.value).toBe('416-555-0123');
+  });
+
+  it('shows an email validation error for invalid emails on blur', () => {
+    render(<ApplicationForm />);
+    const email = screen.getByLabelText(/^email$/i) as HTMLInputElement;
+    fireEvent.change(email, { target: { value: 'not-valid' } });
+    fireEvent.blur(email);
+    expect(screen.getByText(/please enter a valid email address/i)).toBeInTheDocument();
+  });
+
+  it('submits the form data via POST /api/apply', async () => {
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({ ok: true });
+    render(<ApplicationForm />);
+
+    fireEvent.change(screen.getByLabelText(/first name/i), { target: { value: 'Ada' } });
+    fireEvent.change(screen.getByLabelText(/^email$/i), { target: { value: 'a@b.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/apply',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    });
+  });
+});

--- a/client/tests/unit/pages/auth.test.tsx
+++ b/client/tests/unit/pages/auth.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, replace: jest.fn(), prefetch: jest.fn() }),
+}));
+
+const mockLogin = jest.fn();
+const mockRegister = jest.fn();
+const mockGetCurrentUser = jest.fn();
+const mockResendConfirmation = jest.fn();
+const mockResetPassword = jest.fn();
+
+jest.mock('@/utils/auth', () => ({
+  login: (...args: unknown[]) => mockLogin(...args),
+  register: (...args: unknown[]) => mockRegister(...args),
+  getCurrentUser: () => mockGetCurrentUser(),
+  resendConfirmation: (...args: unknown[]) => mockResendConfirmation(...args),
+  resetPassword: (...args: unknown[]) => mockResetPassword(...args),
+  AUTH_ERRORS: {
+    EMAIL_ALREADY_TAKEN: 'EMAIL_ALREADY_TAKEN',
+    EMAIL_NEEDS_CONFIRMATION: 'EMAIL_NEEDS_CONFIRMATION',
+  },
+}));
+
+import AuthPage from '@/app/auth/page';
+
+describe('Auth Page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue(null);
+  });
+
+  it('renders the login form by default', async () => {
+    render(<AuthPage />);
+    expect(await screen.findByRole('heading', { name: 'Log In' })).toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+  });
+
+  it('switches to registration mode when "Create an account" is clicked', async () => {
+    render(<AuthPage />);
+    fireEvent.click(await screen.findByRole('button', { name: /create an account/i }));
+    expect(screen.getByRole('heading', { name: 'Create Account' })).toBeInTheDocument();
+    expect(screen.getByLabelText(/full name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
+  });
+
+  it('shows email validation error when submitting with invalid email', async () => {
+    render(<AuthPage />);
+    await screen.findByRole('heading', { name: 'Log In' });
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'not-an-email' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'pass' } });
+    fireEvent.click(screen.getByRole('button', { name: /log in/i }));
+    expect(await screen.findByText(/please enter a valid email address/i)).toBeInTheDocument();
+  });
+
+  it('calls login and redirects to /profile on successful login', async () => {
+    mockLogin.mockResolvedValue({ user: { id: '1' } });
+    render(<AuthPage />);
+    await screen.findByRole('heading', { name: 'Log In' });
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'a@b.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'password' } });
+    fireEvent.click(screen.getByRole('button', { name: /log in/i }));
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith('a@b.com', 'password');
+      expect(mockPush).toHaveBeenCalledWith('/profile');
+    });
+  });
+
+  it('shows the forgot password panel when the link is clicked', async () => {
+    render(<AuthPage />);
+    fireEvent.click(await screen.findByRole('button', { name: /forgot your password/i }));
+    expect(screen.getByRole('button', { name: /send reset link/i })).toBeInTheDocument();
+  });
+
+  it('redirects already-authenticated users to /profile', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: 'u1', email: 'x@y.com' });
+    render(<AuthPage />);
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/profile'));
+  });
+});

--- a/client/tests/unit/pages/blog.test.tsx
+++ b/client/tests/unit/pages/blog.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const samplePost = (id: number, overrides = {}) => ({
+  title: `Blog ${id}`,
+  date: '2024-01-01',
+  description: 'desc',
+  image: '/img.png',
+  href: `/blog/${id}`,
+  ...overrides,
+});
+
+const mockGetFeatured = jest.fn();
+const mockGetRecent = jest.fn();
+const mockGetArchive = jest.fn();
+
+jest.mock('@/app/blog/api/blog', () => ({
+  __esModule: true,
+  getFeaturedPosts: () => mockGetFeatured(),
+  getRecentPosts: () => mockGetRecent(),
+  getArchivePosts: () => mockGetArchive(),
+}));
+
+jest.mock('@/components/cards/blog-card-large', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => <div data-testid="blog-large">{title}</div>,
+}));
+
+jest.mock('@/components/cards/blog-card-small', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => <div data-testid="blog-small">{title}</div>,
+}));
+
+jest.mock('@/components/cards/blog-list-item', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => <div data-testid="blog-list-item">{title}</div>,
+}));
+
+jest.mock('@/components/heroSection', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => <div data-testid="hero">{title}</div>,
+}));
+
+import BlogPage from '@/app/blog/page';
+
+describe('Blog Page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the loading indicator before posts load', () => {
+    mockGetFeatured.mockImplementation(() => new Promise(() => {}));
+    mockGetRecent.mockImplementation(() => new Promise(() => {}));
+    mockGetArchive.mockImplementation(() => new Promise(() => {}));
+    render(<BlogPage />);
+    expect(screen.getByText(/loading blog content/i)).toBeInTheDocument();
+  });
+
+  it('renders featured, recent, and archive posts after they load', async () => {
+    mockGetFeatured.mockResolvedValue([samplePost(1), samplePost(2), samplePost(3)]);
+    mockGetRecent.mockResolvedValue([samplePost(4)]);
+    mockGetArchive.mockResolvedValue([samplePost(5), samplePost(6)]);
+
+    render(<BlogPage />);
+
+    expect(await screen.findByTestId('blog-large')).toHaveTextContent('Blog 1');
+    expect(screen.getAllByTestId('blog-small').length).toBeGreaterThan(0);
+    expect(screen.getAllByTestId('blog-list-item').length).toBe(2);
+  });
+
+  it('filters archive results based on the search input', async () => {
+    mockGetFeatured.mockResolvedValue([]);
+    mockGetRecent.mockResolvedValue([]);
+    mockGetArchive.mockResolvedValue([
+      samplePost(1, { title: 'Intro to ML' }),
+      samplePost(2, { title: 'Deep Learning' }),
+    ]);
+
+    render(<BlogPage />);
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId('blog-list-item').length).toBe(2)
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/search articles/i), {
+      target: { value: 'deep' },
+    });
+
+    await waitFor(() => {
+      const items = screen.getAllByTestId('blog-list-item');
+      expect(items).toHaveLength(1);
+      expect(items[0]).toHaveTextContent('Deep Learning');
+    });
+  });
+
+  it('shows a fallback message when no archive items match the search', async () => {
+    mockGetFeatured.mockResolvedValue([]);
+    mockGetRecent.mockResolvedValue([]);
+    mockGetArchive.mockResolvedValue([samplePost(1, { title: 'Intro' })]);
+
+    render(<BlogPage />);
+
+    await waitFor(() => expect(screen.getAllByTestId('blog-list-item')).toHaveLength(1));
+
+    fireEvent.change(screen.getByPlaceholderText(/search articles/i), {
+      target: { value: 'nothing-matches' },
+    });
+    expect(await screen.findByText(/no articles found/i)).toBeInTheDocument();
+  });
+});

--- a/client/tests/unit/pages/careers.test.tsx
+++ b/client/tests/unit/pages/careers.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('@/components/heroSection', () => ({
+  __esModule: true,
+  default: ({ title, subtitle }: { title: string; subtitle: string }) => (
+    <div data-testid="hero">
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+    </div>
+  ),
+}));
+
+jest.mock('@/assets/careers.json', () => [
+  {
+    title: 'Software Engineer',
+    department: 'Engineering',
+    division: 'AI',
+    applicationLink: 'https://apply.example.com/1',
+  },
+  {
+    title: 'ML Researcher',
+    department: 'Research',
+    division: '',
+    applicationLink: 'https://apply.example.com/2',
+  },
+]);
+
+import CareersPage from '@/app/careers/page';
+
+describe('Careers Page', () => {
+  it('renders the page hero with title and subtitle', () => {
+    render(<CareersPage />);
+    expect(screen.getByRole('heading', { name: /careers/i })).toBeInTheDocument();
+    expect(screen.getByText(/help shape the future of AI and ML/i)).toBeInTheDocument();
+  });
+
+  it('renders the Open Positions header', () => {
+    render(<CareersPage />);
+    expect(screen.getByRole('heading', { name: /open positions/i })).toBeInTheDocument();
+  });
+
+  it('renders one card per position from the data file', () => {
+    render(<CareersPage />);
+    expect(screen.getByText('Software Engineer')).toBeInTheDocument();
+    expect(screen.getByText('ML Researcher')).toBeInTheDocument();
+  });
+
+  it('renders Apply Now links pointing at the position application URLs', () => {
+    render(<CareersPage />);
+    const applyLinks = screen.getAllByRole('link', { name: /apply now/i });
+    expect(applyLinks).toHaveLength(2);
+    expect(applyLinks[0]).toHaveAttribute('href', 'https://apply.example.com/1');
+    expect(applyLinks[0]).toHaveAttribute('target', '_blank');
+  });
+
+  it('shows the division separator dot only when a division is present', () => {
+    render(<CareersPage />);
+    expect(screen.getAllByText('•').length).toBe(1);
+  });
+});

--- a/client/tests/unit/pages/dashboard.test.tsx
+++ b/client/tests/unit/pages/dashboard.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mockPush = jest.fn();
+const mockGetCurrentUser = jest.fn();
+const mockLogout = jest.fn();
+const mockGetCurrentUserProfile = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@/utils/auth', () => ({
+  getCurrentUser: () => mockGetCurrentUser(),
+  logout: () => mockLogout(),
+}));
+
+jest.mock('@/utils/user', () => ({
+  getCurrentUserProfile: () => mockGetCurrentUserProfile(),
+}));
+
+import DashboardPage from '@/app/dashboard/page';
+
+describe('Dashboard Page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows a loading state while user data is being fetched', () => {
+    mockGetCurrentUser.mockImplementation(() => new Promise(() => {}));
+    render(<DashboardPage />);
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it('redirects to /auth when no user is authenticated', async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+    render(<DashboardPage />);
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/auth'));
+  });
+
+  it('renders the dashboard with the user profile when authenticated', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: '1', email: 'jane@example.com', name: 'Jane' });
+    mockGetCurrentUserProfile.mockResolvedValue({
+      id: '1',
+      name: 'Jane Doe',
+      organization: 'UofT',
+    });
+    render(<DashboardPage />);
+
+    expect(await screen.findByText(/welcome back, jane doe/i)).toBeInTheDocument();
+    expect(screen.getByText('jane@example.com')).toBeInTheDocument();
+    expect(screen.getByText('UofT')).toBeInTheDocument();
+    expect(screen.getByText(/authenticated/i)).toBeInTheDocument();
+  });
+
+  it('logs out and redirects to /auth when Sign Out is clicked', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: '1', email: 'a@b.com', name: 'A' });
+    mockGetCurrentUserProfile.mockResolvedValue({ id: '1', name: 'A', organization: '' });
+    mockLogout.mockResolvedValue(undefined);
+    render(<DashboardPage />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /sign out/i }));
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalledWith('/auth');
+    });
+  });
+
+  it('navigates to /profile when the profile card is clicked', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: '1', email: 'a@b.com', name: 'A' });
+    mockGetCurrentUserProfile.mockResolvedValue({ id: '1', name: 'A' });
+    render(<DashboardPage />);
+
+    const card = await screen.findByText('Your Profile');
+    fireEvent.click(card.parentElement as HTMLElement);
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/profile'));
+  });
+});

--- a/client/tests/unit/pages/departments.test.tsx
+++ b/client/tests/unit/pages/departments.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('@/components/memberList', () => ({
+  PersonCard: ({ name, bio, email }: { name: string; bio: string; email: string }) => (
+    <div data-testid="person-card">
+      <h3>{name}</h3>
+      <p>{bio}</p>
+      <a href={`mailto:${email}`}>{email}</a>
+    </div>
+  ),
+}));
+
+import DepartmentsPage from '@/app/departments/page';
+
+describe('Departments Page', () => {
+  it('renders a PersonCard with the expected props', () => {
+    render(<DepartmentsPage />);
+    expect(screen.getByTestId('person-card')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Ambrose Ling' })).toBeInTheDocument();
+    expect(screen.getByText(/space it can hold/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'myEmail@mail.com' })).toHaveAttribute(
+      'href',
+      'mailto:myEmail@mail.com'
+    );
+  });
+});

--- a/client/tests/unit/pages/dev-dropdown.test.tsx
+++ b/client/tests/unit/pages/dev-dropdown.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('@/components/ui/dropdown', () => ({
+  Dropdown: ({
+    label,
+    placeholder,
+    helperText,
+    error,
+    disabled,
+  }: {
+    label?: string;
+    placeholder?: string;
+    helperText?: string;
+    error?: string;
+    disabled?: boolean;
+  }) => (
+    <div data-testid="dropdown" data-disabled={disabled ? 'true' : 'false'}>
+      {label && <label>{label}</label>}
+      <span>{placeholder}</span>
+      {helperText && <small>{helperText}</small>}
+      {error && <p role="alert">{error}</p>}
+    </div>
+  ),
+}));
+
+import DropdownDemoPage from '@/app/dev/dropdown/page';
+
+describe('Dev Dropdown Demo Page', () => {
+  it('renders the page heading and intro copy', () => {
+    render(<DropdownDemoPage />);
+    expect(
+      screen.getByRole('heading', { name: /dropdown component preview/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders three demo dropdowns (controlled, uncontrolled, disabled)', () => {
+    render(<DropdownDemoPage />);
+    const dropdowns = screen.getAllByTestId('dropdown');
+    expect(dropdowns).toHaveLength(3);
+  });
+
+  it('shows the controlled selection initially as ai2', () => {
+    render(<DropdownDemoPage />);
+    expect(screen.getByText(/Selected value: ai2/i)).toBeInTheDocument();
+  });
+
+  it('renders the disabled dropdown with its error message', () => {
+    render(<DropdownDemoPage />);
+    expect(
+      screen.getByText(/feature locked until profile is completed/i)
+    ).toBeInTheDocument();
+    const dropdowns = screen.getAllByTestId('dropdown');
+    expect(dropdowns[2]).toHaveAttribute('data-disabled', 'true');
+  });
+});

--- a/client/tests/unit/pages/eigenai.test.tsx
+++ b/client/tests/unit/pages/eigenai.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('@/components/peopleGrid', () => ({
+  __esModule: true,
+  default: ({ people }: { people: Array<{ name: string }> }) => (
+    <div data-testid="people-grid">{people.length}</div>
+  ),
+}));
+
+jest.mock('@/components/lambda', () => ({
+  __esModule: true,
+  default: () => <div data-testid="lambda-section" />,
+}));
+
+jest.mock('@/components/workshops', () => ({
+  __esModule: true,
+  default: () => <div data-testid="workshops" />,
+}));
+
+jest.mock('@/app/eigenai/data', () => ({
+  founderPanelSpeakers: [{ name: 'Founder A' }],
+  researchPanelSpeakers: [{ name: 'Researcher A' }],
+  keynoteSpeakers: [{ name: 'Keynote A' }],
+  speakerSession: [{ name: 'Speaker A' }, { name: 'Speaker B' }, { name: 'Speaker C' }],
+}));
+
+describe('EigenAI Page', () => {
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY = 'test-key';
+  });
+
+  it('renders hero, intro, and skill-level sections', async () => {
+    const { default: EigenAIPage } = await import('@/app/eigenai/page');
+    render(<EigenAIPage />);
+    expect(screen.getByRole('heading', { name: 'EigenAI' })).toBeInTheDocument();
+    expect(screen.getByText(/What is EigenAI\?/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/EigenAI is built for AI practitioners of all skill levels/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the keynote, panel, and speaker people grids', async () => {
+    const { default: EigenAIPage } = await import('@/app/eigenai/page');
+    render(<EigenAIPage />);
+    const grids = screen.getAllByTestId('people-grid');
+    expect(grids.length).toBeGreaterThan(0);
+  });
+
+  it('renders the Lambda and Workshops sections', async () => {
+    const { default: EigenAIPage } = await import('@/app/eigenai/page');
+    render(<EigenAIPage />);
+    expect(screen.getByTestId('lambda-section')).toBeInTheDocument();
+    expect(screen.getByTestId('workshops')).toBeInTheDocument();
+  });
+
+  it('throws an explicit error when the Google Maps API key is missing', async () => {
+    jest.resetModules();
+    const previous = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+    delete process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+
+    const { default: EigenAIPage } = await import('@/app/eigenai/page');
+    expect(() => render(<EigenAIPage />)).toThrow(
+      /Google Maps API key is not defined/
+    );
+
+    process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY = previous;
+  });
+});

--- a/client/tests/unit/pages/events.test.tsx
+++ b/client/tests/unit/pages/events.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mockGetUpcoming = jest.fn();
+const mockGetPast = jest.fn();
+const mockGetFeatured = jest.fn();
+
+jest.mock('@/app/events/api/events', () => ({
+  __esModule: true,
+  getUpcomingEvents: () => mockGetUpcoming(),
+  getPastEvents: () => mockGetPast(),
+  getFeaturedEvents: () => mockGetFeatured(),
+}));
+
+jest.mock('@/app/events/components/event-item', () => ({
+  EventItem: ({ event }: { event: { id: string; title: string } }) => (
+    <div data-testid="event-item">{event.title}</div>
+  ),
+}));
+
+jest.mock('@/app/events/components/search-bar', () => ({
+  SearchBar: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <input
+      data-testid="search-bar"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+jest.mock('@/app/events/components/tag-filter', () => ({
+  TagFilter: () => <div data-testid="tag-filter" />,
+}));
+
+jest.mock('@/app/events/components/event-card', () => ({
+  EventCard: ({ title }: { title: string }) => <div data-testid="event-card">{title}</div>,
+}));
+
+jest.mock('@/components/heroSection', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => <div data-testid="hero">{title}</div>,
+}));
+
+import EventsPage from '@/app/events/page';
+
+describe('Events Page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('displays the loading state while events are being fetched', () => {
+    mockGetUpcoming.mockImplementation(() => new Promise(() => {}));
+    mockGetPast.mockImplementation(() => new Promise(() => {}));
+    mockGetFeatured.mockImplementation(() => new Promise(() => {}));
+    render(<EventsPage />);
+    expect(screen.getByText(/loading events/i)).toBeInTheDocument();
+  });
+
+  it('renders upcoming, past, and featured events after loading', async () => {
+    mockGetUpcoming.mockResolvedValue([
+      { id: 'u1', title: 'Upcoming One', location: 'BA', description: 'd', tags: ['ml'] },
+    ]);
+    mockGetPast.mockResolvedValue([
+      {
+        id: 'p1',
+        title: 'Past One',
+        instructor: 'Jane',
+        overview: 'o',
+        learningGoals: ['g'],
+        tags: ['nlp'],
+      },
+    ]);
+    mockGetFeatured.mockResolvedValue([
+      { title: 'Featured Hackathon', url: 'https://e.com', background: '#fff' },
+    ]);
+
+    render(<EventsPage />);
+
+    expect(await screen.findByText('Upcoming One')).toBeInTheDocument();
+    expect(screen.getByText('Past One')).toBeInTheDocument();
+    expect(screen.getByText('Featured Hackathon')).toBeInTheDocument();
+  });
+
+  it('filters upcoming events by search query', async () => {
+    mockGetUpcoming.mockResolvedValue([
+      { id: 'u1', title: 'Workshop A', location: 'X', description: 'd', tags: [] },
+      { id: 'u2', title: 'Hackathon B', location: 'Y', description: 'd', tags: [] },
+    ]);
+    mockGetPast.mockResolvedValue([]);
+    mockGetFeatured.mockResolvedValue([]);
+
+    render(<EventsPage />);
+    await waitFor(() => expect(screen.getAllByTestId('event-item')).toHaveLength(2));
+
+    const searchBars = screen.getAllByTestId('search-bar');
+    fireEvent.change(searchBars[0], { target: { value: 'hackathon' } });
+
+    await waitFor(() => {
+      const items = screen.getAllByTestId('event-item');
+      expect(items).toHaveLength(1);
+      expect(items[0]).toHaveTextContent('Hackathon B');
+    });
+  });
+
+  it('shows a placeholder message when there are no upcoming events', async () => {
+    mockGetUpcoming.mockResolvedValue([]);
+    mockGetPast.mockResolvedValue([]);
+    mockGetFeatured.mockResolvedValue([]);
+
+    render(<EventsPage />);
+    expect(await screen.findByText(/more events are in the works/i)).toBeInTheDocument();
+  });
+});

--- a/client/tests/unit/pages/home.test.tsx
+++ b/client/tests/unit/pages/home.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('@/components/cards/hero-card', () => ({
+  __esModule: true,
+  default: ({ title, description }: { title: string; description: string }) => (
+    <div data-testid="hero-card">
+      <h3>{title}</h3>
+      <p>{description}</p>
+    </div>
+  ),
+}));
+
+jest.mock('@/components/sponsors', () => ({
+  __esModule: true,
+  default: () => <div data-testid="sponsors" />,
+}));
+
+jest.mock('@/components/stats', () => ({
+  __esModule: true,
+  default: () => <div data-testid="stats" />,
+}));
+
+jest.mock('@/components/events', () => ({
+  __esModule: true,
+  default: () => <div data-testid="events" />,
+}));
+
+jest.mock('@/components/valueprops', () => ({
+  __esModule: true,
+  default: () => <div data-testid="valueprops" />,
+}));
+
+jest.mock('@/components/startupsSection', () => ({
+  __esModule: true,
+  default: () => <div data-testid="startups-section" />,
+}));
+
+jest.mock('@/components/faq', () => ({
+  __esModule: true,
+  default: () => <div data-testid="faq" />,
+}));
+
+import Home from '@/app/page';
+
+describe('Home Page', () => {
+  it('renders the hero title and subtitle', () => {
+    render(<Home />);
+    expect(screen.getByText('Clear The MIST')).toBeInTheDocument();
+    expect(
+      screen.getByText(/University of Toronto Machine Intelligence Student Team/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders Join Us and Contact Us call-to-action links', () => {
+    render(<Home />);
+    const joinLink = screen.getByRole('link', { name: /join us/i });
+    expect(joinLink).toHaveAttribute('href', '/careers');
+
+    const contactLink = screen.getByRole('link', { name: /contact us/i });
+    expect(contactLink).toHaveAttribute('href', expect.stringContaining('mailto:'));
+  });
+
+  it('renders the Who We Are and Our Mission hero cards', () => {
+    render(<Home />);
+    expect(screen.getByText('Who We Are')).toBeInTheDocument();
+    expect(screen.getByText('Our Mission')).toBeInTheDocument();
+  });
+
+  it('renders all major homepage sections', () => {
+    render(<Home />);
+    expect(screen.getByTestId('sponsors')).toBeInTheDocument();
+    expect(screen.getByTestId('stats')).toBeInTheDocument();
+    expect(screen.getByTestId('events')).toBeInTheDocument();
+    expect(screen.getByTestId('valueprops')).toBeInTheDocument();
+    expect(screen.getByTestId('startups-section')).toBeInTheDocument();
+    expect(screen.getByTestId('faq')).toBeInTheDocument();
+  });
+});

--- a/client/tests/unit/pages/ml-fundamentals.test.tsx
+++ b/client/tests/unit/pages/ml-fundamentals.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+jest.mock('@/components/heroSection', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => <div data-testid="hero">{title}</div>,
+}));
+
+jest.mock('@/components/peopleGrid', () => ({
+  __esModule: true,
+  default: ({ people }: { people: Array<{ name: string }> }) => (
+    <div data-testid="people-grid">{people.length}</div>
+  ),
+}));
+
+jest.mock('@/app/ml-fundamentals/data', () => ({
+  programDirectors: [{ name: 'Director A' }],
+  academicsTeam: [{ name: 'Academic A' }, { name: 'Academic B' }],
+  techWritersTeam: [{ name: 'Writer A' }],
+}));
+
+import MLFundamentals from '@/app/ml-fundamentals/page';
+
+describe('ML Fundamentals Page', () => {
+  it('renders both Phase 1 and Phase 2 schedule sections', () => {
+    render(<MLFundamentals />);
+    expect(screen.getByText(/Phase 1: Workshop Schedule/i)).toBeInTheDocument();
+    expect(screen.getByText(/Phase 2: Project/i)).toBeInTheDocument();
+  });
+
+  it('renders all eight Phase 1 weeks', () => {
+    render(<MLFundamentals />);
+    expect(screen.getByText(/Introduction to Machine Learning/i)).toBeInTheDocument();
+    expect(screen.getByText(/Deep Learning & Modern Architectures/i)).toBeInTheDocument();
+  });
+
+  it('opens the workshop modal when a Slides button is clicked', () => {
+    render(<MLFundamentals />);
+    const slideButtons = screen.getAllByRole('button', { name: /slides/i });
+    fireEvent.click(slideButtons[0]);
+    expect(screen.getAllByText(/Introduction to Machine Learning/i).length).toBeGreaterThan(1);
+  });
+
+  it('toggles an FAQ open and shows its answer', () => {
+    render(<MLFundamentals />);
+    const faq = screen.getByText(/what prerequisites do I need/i);
+    fireEvent.click(faq);
+    expect(
+      screen.getByText(/basic knowledge of python programming/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders three people-grid sections for the team', () => {
+    render(<MLFundamentals />);
+    const grids = screen.getAllByTestId('people-grid');
+    expect(grids).toHaveLength(3);
+  });
+});

--- a/client/tests/unit/pages/profile.test.tsx
+++ b/client/tests/unit/pages/profile.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+const mockPush = jest.fn();
+const mockGetCurrentUser = jest.fn();
+const mockGetCurrentUserProfile = jest.fn();
+const mockLogout = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@/utils/auth', () => ({
+  getCurrentUser: () => mockGetCurrentUser(),
+  logout: () => mockLogout(),
+}));
+
+jest.mock('@/utils/user', () => ({
+  getCurrentUserProfile: () => mockGetCurrentUserProfile(),
+}));
+
+jest.mock('@/components/profile/ProfileCard', () => ({
+  __esModule: true,
+  default: ({ userProfile }: { userProfile: { name: string } }) => (
+    <div data-testid="profile-card">{userProfile.name}</div>
+  ),
+}));
+
+jest.mock('@/components/profile/ProfileEditForm', () => ({
+  __esModule: true,
+  default: () => <div data-testid="profile-edit-form" />,
+}));
+
+jest.mock('@/components/profile/SocialCard', () => ({
+  __esModule: true,
+  default: () => <div data-testid="social-card" />,
+}));
+
+jest.mock('@/components/profile/QRCodeCard', () => ({
+  __esModule: true,
+  default: () => <div data-testid="qr-card" />,
+}));
+
+jest.mock('@/components/profile/ResumeCard', () => ({
+  __esModule: true,
+  default: () => <div data-testid="resume-card" />,
+}));
+
+jest.mock('@/components/profile/AdminCard', () => ({
+  __esModule: true,
+  default: () => <div data-testid="admin-card" />,
+}));
+
+import ProfilePage from '@/app/profile/page';
+
+describe('Profile Page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows a loading state initially', () => {
+    mockGetCurrentUser.mockImplementation(() => new Promise(() => {}));
+    render(<ProfilePage />);
+    expect(screen.getByText(/loading profile/i)).toBeInTheDocument();
+  });
+
+  it('redirects to /auth if no user is authenticated', async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+    render(<ProfilePage />);
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/auth'));
+  });
+
+  it('renders profile cards once data has loaded', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: '1', email: 'a@b.com' });
+    mockGetCurrentUserProfile.mockResolvedValue({
+      id: '1',
+      name: 'Jane',
+      admin: false,
+      linkedin: 'jd',
+      github: 'jd',
+      twitter: 'jd',
+      year: 2026,
+    });
+    render(<ProfilePage />);
+
+    expect(await screen.findByTestId('profile-card')).toHaveTextContent('Jane');
+    expect(screen.getByTestId('social-card')).toBeInTheDocument();
+    expect(screen.getByTestId('resume-card')).toBeInTheDocument();
+    expect(screen.getByTestId('qr-card')).toBeInTheDocument();
+    expect(screen.queryByTestId('admin-card')).not.toBeInTheDocument();
+  });
+
+  it('renders the AdminCard when the profile has admin privileges', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: '1' });
+    mockGetCurrentUserProfile.mockResolvedValue({ id: '1', name: 'Admin', admin: true });
+    render(<ProfilePage />);
+    expect(await screen.findByTestId('admin-card')).toBeInTheDocument();
+  });
+
+  it('renders an error UI if loading the profile throws', async () => {
+    mockGetCurrentUser.mockRejectedValue(new Error('boom'));
+    render(<ProfilePage />);
+    expect(await screen.findByText(/error loading profile/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+});

--- a/client/tests/unit/pages/projects.test.tsx
+++ b/client/tests/unit/pages/projects.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+
+jest.mock('@/components/carousel', () => ({
+  ProjectCarousel: ({ projects }: { projects: Array<{ title: string }> }) => (
+    <div data-testid="project-carousel">{projects.length}</div>
+  ),
+}));
+
+jest.mock('@/components/heroSection', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => <div data-testid="hero">{title}</div>,
+}));
+
+jest.mock('@/assets/projects.json', () => [
+  {
+    name: 'Generative Project',
+    description: 'A generative AI project',
+    type: 'genai',
+    github: 'https://github.com/x/y',
+    readMoreLink: '#',
+  },
+  {
+    name: 'Vision Project',
+    description: 'A computer vision experiment',
+    type: 'cvpr',
+    github: '',
+    readMoreLink: '#',
+  },
+]);
+
+import ProjectsPage from '@/app/projects/page';
+
+describe('Projects Page', () => {
+  it('renders the Projects hero', () => {
+    render(<ProjectsPage />);
+    expect(screen.getByTestId('hero')).toHaveTextContent('Projects');
+  });
+
+  it('renders all project titles in the See All Projects grid', () => {
+    render(<ProjectsPage />);
+    expect(screen.getAllByText('Generative Project').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Vision Project').length).toBeGreaterThan(0);
+  });
+
+  it('filters the See-All grid based on the search input', () => {
+    render(<ProjectsPage />);
+
+    // Pre-filter: both projects appear in the See-All grid
+    expect(screen.getAllByText('Generative Project').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Vision Project').length).toBeGreaterThanOrEqual(1);
+
+    const search = screen.getByPlaceholderText(/search projects/i);
+    fireEvent.change(search, { target: { value: 'generative' } });
+
+    // After filtering, only Generative Project remains visible in the grid
+    expect(screen.getAllByText('Generative Project').length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText('Vision Project')).not.toBeInTheDocument();
+  });
+
+  it('renders one carousel per project type that has projects', () => {
+    render(<ProjectsPage />);
+    const carousels = screen.getAllByTestId('project-carousel');
+    expect(carousels.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/client/tests/unit/pages/reset-password.test.tsx
+++ b/client/tests/unit/pages/reset-password.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mockPush = jest.fn();
+const mockGetUser = jest.fn();
+const mockUpdateUser = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@/lib/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getUser: () => mockGetUser(),
+      updateUser: (...args: unknown[]) => mockUpdateUser(...args),
+    },
+  },
+}));
+
+import ResetPasswordPage from '@/app/auth/reset-password/page';
+
+describe('Reset Password Page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: { id: '1' } } });
+  });
+
+  it('redirects to /auth?error=reset_expired when the user is not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    render(<ResetPasswordPage />);
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith('/auth?error=reset_expired')
+    );
+  });
+
+  it('renders the password reset form', async () => {
+    render(<ResetPasswordPage />);
+    expect(
+      await screen.findByRole('heading', { name: /reset your password/i })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('New Password')).toBeInTheDocument();
+    expect(screen.getByLabelText('Confirm New Password')).toBeInTheDocument();
+  });
+
+  it('shows a "Password is required" error when the password is empty', async () => {
+    render(<ResetPasswordPage />);
+    fireEvent.click(await screen.findByRole('button', { name: /update password/i }));
+    expect(await screen.findByText('Password is required')).toBeInTheDocument();
+  });
+
+  it('shows a length error when the password is too short', async () => {
+    render(<ResetPasswordPage />);
+    fireEvent.change(await screen.findByLabelText('New Password'), {
+      target: { value: 'short' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm New Password'), {
+      target: { value: 'short' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+    expect(await screen.findByText(/at least 8 characters/i)).toBeInTheDocument();
+  });
+
+  it('shows a mismatch error when the two password fields differ', async () => {
+    render(<ResetPasswordPage />);
+    fireEvent.change(await screen.findByLabelText('New Password'), {
+      target: { value: 'longenough123' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm New Password'), {
+      target: { value: 'mismatchhere' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+    expect(await screen.findByText(/passwords do not match/i)).toBeInTheDocument();
+  });
+
+  it('calls updateUser and shows the success state on a valid submit', async () => {
+    mockUpdateUser.mockResolvedValue({ error: null });
+    render(<ResetPasswordPage />);
+
+    fireEvent.change(await screen.findByLabelText('New Password'), {
+      target: { value: 'StrongPass123!' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm New Password'), {
+      target: { value: 'StrongPass123!' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledWith({ password: 'StrongPass123!' });
+    });
+    expect(await screen.findByText(/password reset successful/i)).toBeInTheDocument();
+  });
+
+  it('navigates back to /auth when "Back to Login" is clicked', async () => {
+    render(<ResetPasswordPage />);
+    fireEvent.click(await screen.findByRole('button', { name: /back to login/i }));
+    expect(mockPush).toHaveBeenCalledWith('/auth');
+  });
+});

--- a/client/tests/unit/pages/sponsors.test.tsx
+++ b/client/tests/unit/pages/sponsors.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('@/components/heroSection', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => <div data-testid="hero">{title}</div>,
+}));
+
+jest.mock('@/components/cards/sponsor-card', () => ({
+  __esModule: true,
+  default: ({ category, price }: { category: string; price: string }) => (
+    <div data-testid="sponsor-card">
+      <h3>{category}</h3>
+      <span>{price}</span>
+    </div>
+  ),
+}));
+
+jest.mock('@/components/cards/contact-us-card', () => ({
+  __esModule: true,
+  default: () => <div data-testid="contact-us-card" />,
+}));
+
+jest.mock('@/assets/sponsors.json', () => [
+  { category: 'Gold', price: '$5000', perks: ['Logo on website'] },
+  { category: 'Silver', price: '$2000', perks: ['Mention in newsletter'] },
+]);
+
+import SponsorsPage from '@/app/sponsors/page';
+
+describe('Sponsors Page', () => {
+  it('renders the Sponsor Us section', () => {
+    render(<SponsorsPage />);
+    expect(screen.getByRole('heading', { name: /sponsor us/i })).toBeInTheDocument();
+  });
+
+  it('renders one sponsor card per tier from the data file', () => {
+    render(<SponsorsPage />);
+    const cards = screen.getAllByTestId('sponsor-card');
+    expect(cards).toHaveLength(2);
+    expect(screen.getByText('Gold')).toBeInTheDocument();
+    expect(screen.getByText('Silver')).toBeInTheDocument();
+  });
+
+  it('renders the contact-us section', () => {
+    render(<SponsorsPage />);
+    expect(screen.getByTestId('contact-us-card')).toBeInTheDocument();
+  });
+});

--- a/client/tests/unit/pages/startups.test.tsx
+++ b/client/tests/unit/pages/startups.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import StartupsPage from '@/app/startups/page';
+
+describe('Startups Page', () => {
+  it('renders the MISTic R&D hero title', () => {
+    render(<StartupsPage />);
+    expect(screen.getByRole('heading', { name: /MISTic R&D/i })).toBeInTheDocument();
+  });
+
+  it('renders the Startups @ UTMIST sub-section', () => {
+    render(<StartupsPage />);
+    expect(screen.getByRole('heading', { name: /Startups @ UTMIST/i })).toBeInTheDocument();
+  });
+
+  it('renders all three featured startups', () => {
+    render(<StartupsPage />);
+    expect(screen.getByText('Caid')).toBeInTheDocument();
+    expect(screen.getByText('BuildSafe')).toBeInTheDocument();
+    expect(screen.getByText('ClearSite.ai')).toBeInTheDocument();
+  });
+
+  it('renders the Our Partners section with both partners', () => {
+    render(<StartupsPage />);
+    expect(screen.getByRole('heading', { name: /Our Partners/i })).toBeInTheDocument();
+    expect(screen.getByText('Front Row Ventures')).toBeInTheDocument();
+    expect(screen.getByText('Forum Ventures')).toBeInTheDocument();
+  });
+});

--- a/docs/client/Testing.md
+++ b/docs/client/Testing.md
@@ -1,0 +1,299 @@
+# Client Testing Guide
+
+This guide explains how the UTMIST client test suite is organized and how to add new tests.
+
+## Stack
+
+- **Test runner:** Jest 30 (`jest`, `jest-environment-jsdom`)
+- **Component testing:** React Testing Library (`@testing-library/react`, `@testing-library/jest-dom`, `@testing-library/user-event`)
+- **TypeScript:** `ts-jest` via the `next/jest` preset
+- **Configuration:** [`client/jest.config.js`](../../client/jest.config.js) and [`client/jest.setup.js`](../../client/jest.setup.js)
+
+## Running tests
+
+```bash
+cd UTMIST/client
+
+npm test                  # run all tests once
+npm run test:watch        # re-run on file changes
+npm run test:coverage     # with v8 coverage report
+npm run test:unit         # only tests/unit
+npm run test:integration  # only tests/integration
+
+# subset by path or test name:
+npx jest tests/unit/pages              # all 20 page suites
+npx jest tests/unit/pages/auth         # one file (path substring match)
+npx jest -t "redirects to /auth"       # by test-name regex
+```
+
+## Directory layout
+
+```
+client/tests/
+├── unit/
+│   ├── pages/             # one *.test.tsx file per route in src/app
+│   └── validation.test.ts # utility-level unit tests
+├── integration/
+│   └── auth.test.ts       # end-to-end-style flow tests
+└── utils/
+    └── test-utils.ts      # shared mocks, fixtures, helpers
+```
+
+Tests are discovered by the pattern `tests/**/*.(test|spec).(js|jsx|ts|tsx)` (see `jest.config.js`). New page tests must go in `tests/unit/pages/`.
+
+## Globals already mocked for you
+
+[`jest.setup.js`](../../client/jest.setup.js) auto-applies these to every test:
+
+- `next/navigation` — `useRouter`, `useSearchParams`, `usePathname` return jest mocks. **Override per file** if you need to inspect calls (see "Auth flows" below).
+- `next/image` — replaced with a plain `<img>` so tests do not need a real loader.
+- `global.fetch` — set to `jest.fn()`; rebind it per test as needed.
+- `process.env.NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` — populated with test values.
+- `console.error` — suppresses the noisy `ReactDOM.render is deprecated` warning only.
+
+## Path alias
+
+The `@/` alias is mapped to `client/src/` via `moduleNameMapper` in `jest.config.js`. Use it the same way as in app code:
+
+```ts
+import HomePage from '@/app/page';
+import { login } from '@/utils/auth';
+```
+
+## Standard page-test template
+
+Every page test in `tests/unit/pages/` follows this shape:
+
+```tsx
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// 1. Mock declarations FIRST. jest.mock is hoisted, but for clarity place
+//    every mock above the page import.
+jest.mock('@/components/heroSection', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => (
+    <div data-testid="hero">{title}</div>
+  ),
+}));
+
+// 2. Import the page UNDER TEST after the mocks.
+import MyPage from '@/app/my-route/page';
+
+describe('My Page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the hero title', () => {
+    render(<MyPage />);
+    expect(screen.getByTestId('hero')).toHaveTextContent('Welcome');
+  });
+});
+```
+
+Rules of thumb:
+
+- **Mock heavy or leaf components** (carousels, people grids, third-party widgets) so a page test only fails when the page itself breaks. Real, simple sub-components can be left unmocked.
+- **One `describe` block per page**, named after the page.
+- **`it('does X')` not `it('should do X')`** — match the existing suite's voice.
+- **Mock external IO at the boundary**: `fetch`, Supabase clients, `next/navigation`, route-local `./api/*` modules.
+
+## Cookbooks
+
+### Mocking `next/navigation` to assert redirects
+
+```tsx
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// ...
+await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/auth'));
+```
+
+For `useParams` (dynamic routes like `applicants/[profile]`):
+
+```tsx
+const mockUseParams = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useParams: () => mockUseParams(),
+}));
+
+mockUseParams.mockReturnValue({ profile: 'a1' });
+```
+
+### Mocking `fetch`
+
+```tsx
+(global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+  ok: true,
+  json: async () => ({ items: [] }),
+});
+
+// later, assert request shape:
+expect(global.fetch).toHaveBeenCalledWith(
+  '/api/apply',
+  expect.objectContaining({ method: 'POST' })
+);
+```
+
+### Mocking Supabase
+
+For client components that import `@/lib/supabase/client`:
+
+```tsx
+const mockGetUser = jest.fn();
+const mockUpdateUser = jest.fn();
+
+jest.mock('@/lib/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getUser: () => mockGetUser(),
+      updateUser: (...args: unknown[]) => mockUpdateUser(...args),
+    },
+  },
+}));
+```
+
+For server components that use `createClient()` from `@/lib/supabase/server`, see "Server components" below.
+
+### Auth flows (`@/utils/auth`, `@/utils/user`)
+
+```tsx
+const mockLogin = jest.fn();
+const mockGetCurrentUser = jest.fn();
+
+jest.mock('@/utils/auth', () => ({
+  login: (...args: unknown[]) => mockLogin(...args),
+  getCurrentUser: () => mockGetCurrentUser(),
+  AUTH_ERRORS: {
+    EMAIL_ALREADY_TAKEN: 'EMAIL_ALREADY_TAKEN',
+    EMAIL_NEEDS_CONFIRMATION: 'EMAIL_NEEDS_CONFIRMATION',
+  },
+}));
+```
+
+Set `mockGetCurrentUser.mockResolvedValue(null)` in `beforeEach` so unauthenticated is the default; opt into the authenticated case per test.
+
+### JSON data fixtures
+
+Pages frequently `import data from '@/assets/something.json'`. Mock the import to a small, predictable fixture:
+
+```tsx
+jest.mock('@/assets/careers.json', () => [
+  { title: 'SWE', department: 'Eng', division: 'AI', applicationLink: 'https://x.com' },
+]);
+```
+
+### Server (async) components
+
+Server components like [`src/app/admin/page.tsx`](../../client/src/app/admin/page.tsx) are `async function`s that `await createClient()` and call `redirect()`. Test them by:
+
+1. Mocking `redirect` to throw a sentinel error so you can assert the path.
+2. Calling the page directly and rendering the resolved JSX.
+
+```tsx
+const mockRedirect = jest.fn((path: string) => {
+  throw new Error(`__REDIRECT__:${path}`);
+});
+
+jest.mock('next/navigation', () => ({
+  redirect: (path: string) => mockRedirect(path),
+}));
+
+// Redirect path assertion:
+await expect(AdminPage()).rejects.toThrow('__REDIRECT__:/auth');
+
+// Render path:
+const node = await AdminPage();
+render(node);
+```
+
+### Modules that throw at import time (env-var checks)
+
+`eigenai/page.tsx` throws if `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` is unset. To exercise both branches:
+
+```tsx
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY = 'test-key';
+});
+
+// happy path
+const { default: EigenAIPage } = await import('@/app/eigenai/page');
+
+// error path
+jest.resetModules();
+delete process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+const { default: EigenAIPage } = await import('@/app/eigenai/page');
+expect(() => render(<EigenAIPage />)).toThrow(/Google Maps API key is not defined/);
+```
+
+### ESM-only third-party libraries
+
+`react-chrono`, `keen-slider`, `framer-motion`, etc. ship as ESM and may fail to transform under Jest. Mock them to thin stubs:
+
+```tsx
+jest.mock('react-chrono', () => ({
+  Chrono: ({ items }: { items: Array<{ title?: string }> }) => (
+    <div data-testid="chrono">{items.length}</div>
+  ),
+}));
+```
+
+## Querying conventions
+
+In rough preference order (matches Testing Library's [priority list](https://testing-library.com/docs/queries/about/#priority)):
+
+1. `getByRole('heading', { name: /…/i })` — most accessible
+2. `getByLabelText('New Password')` — form fields. Prefer **exact strings** over regex when fields share substrings (e.g., "New Password" vs "Confirm New Password")
+3. `getByPlaceholderText`, `getByText`
+4. `getByTestId` — last resort, useful when mocking child components
+
+For asynchronous UI (after `useEffect` fetches), prefer `findBy*` and `waitFor`:
+
+```tsx
+expect(await screen.findByText(/loaded/i)).toBeInTheDocument();
+await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+```
+
+## What each kind of page test should cover
+
+For each page, aim to cover at least:
+
+- **Render path** — the page mounts without throwing; key headings/sections appear.
+- **Data binding / props validation** — values from `*.json` fixtures, dynamic params, or props on mocked children show up correctly.
+- **User interactions** — click, type, submit, toggle. One assertion per interaction is enough.
+- **Async states** — loading, success, error. Use `mockImplementation(() => new Promise(() => {}))` to keep the page in the loading state for assertion.
+- **Edge cases** — empty results, missing/null fields, redirect-when-unauthenticated, validation errors.
+
+Bias toward few high-signal tests per page over exhaustive coverage. Each test should fail for exactly one reason.
+
+## Reference: existing examples
+
+When in doubt, copy the closest existing test:
+
+| If your page… | Look at… |
+| --- | --- |
+| is a static server component with sub-cards | [`tests/unit/pages/careers.test.tsx`](../../client/tests/unit/pages/careers.test.tsx), [`sponsors.test.tsx`](../../client/tests/unit/pages/sponsors.test.tsx) |
+| is a client component that fetches on mount | [`blog.test.tsx`](../../client/tests/unit/pages/blog.test.tsx), [`events.test.tsx`](../../client/tests/unit/pages/events.test.tsx) |
+| has a form with validation | [`apply.test.tsx`](../../client/tests/unit/pages/apply.test.tsx), [`reset-password.test.tsx`](../../client/tests/unit/pages/reset-password.test.tsx), [`auth.test.tsx`](../../client/tests/unit/pages/auth.test.tsx) |
+| is auth-gated and redirects | [`dashboard.test.tsx`](../../client/tests/unit/pages/dashboard.test.tsx), [`profile.test.tsx`](../../client/tests/unit/pages/profile.test.tsx) |
+| is an async server component | [`admin.test.tsx`](../../client/tests/unit/pages/admin.test.tsx) |
+| uses a dynamic route param | [`applicants-profile.test.tsx`](../../client/tests/unit/pages/applicants-profile.test.tsx) |
+| reads an env var at import time | [`eigenai.test.tsx`](../../client/tests/unit/pages/eigenai.test.tsx) |
+| has a tabbed/modal interaction | [`ai2.test.tsx`](../../client/tests/unit/pages/ai2.test.tsx), [`ml-fundamentals.test.tsx`](../../client/tests/unit/pages/ml-fundamentals.test.tsx) |
+
+## CI
+
+Tests are intended to run in CI as part of the build. The recommended invocation is `npm test` (no watcher, exits non-zero on failure). For coverage thresholds, configure them under the `coverageThreshold` key in `jest.config.js`.
+
+## Troubleshooting
+
+- **`Cannot find module '@/…'`** — `moduleNameMapper` is missing from `jest.config.js`. The `@/` alias must be mapped explicitly; `next/jest` does not auto-map it.
+- **`Found multiple elements`** — your text/role query is too broad. Use exact strings, anchor the regex with `^…$`, or filter with `level`/`name` options on `getByRole`.
+- **`Unable to fire a "change" event - please provide a DOM element`** — your DOM lookup returned `null`. Prefer `container.querySelector('#id')` or `getByLabelText` over `parentElement` chains.
+- **`act()` warnings** — wrap state-updating interactions in `await waitFor(...)` or use `findBy*` queries instead of `getBy*`.
+- **A third-party module fails to parse** — it is probably ESM-only. Mock it with `jest.mock('package-name', () => ({ … }))`.


### PR DESCRIPTION
fixes https://github.com/UTMIST/UTMIST/issues/17
- 20 page test suites under client/tests/unit/pages covering rendering,
  user interactions, props validation, and edge cases (loading/error/
  redirect states, empty results, missing env vars, form validation)
- 130 tests total, all passing via `npm test`
- jest.config.js: add `moduleNameMapper` for the `@/` alias so tests
  can import from src/ the same way app code does
- docs/client/Testing.md: contributor guide with template, mocking
  cookbooks (next/navigation, fetch, Supabase, async server components,
  env-throw modules), querying conventions, and a reference table
  mapping page archetypes to existing examples
