### PR TITLE
feat: add detailed project information modal (popup)

### DIFF
--- a/client/src/app/projects/page.tsx
+++ b/client/src/app/projects/page.tsx
@@ -1,13 +1,12 @@
 "use client";
 // import "@/styles/projects.css";
 import React, { useState } from "react";
-import Image from "next/image";
 import { Search } from "lucide-react";
 import projectsData from "@/assets/projects.json";
-import githubIcon from "@/assets/logos/github.svg";
 import dummy from "@/assets/photos/fibseq.webp";
 import { ProjectCarousel } from "@/components/carousel";
 import { ProjectType, Project } from "@/types/projects";
+import ProjectCard from "@/components/cards/project-card";
 import HeroSection from "@/components/heroSection";
 
 export default function ProjectsPage() {
@@ -31,7 +30,20 @@ export default function ProjectsPage() {
     aiapps: ProjectType.aiapps,
   };
 
-  const projects: Project[] = projectsData.map((project) => ({
+  type RawProject = {
+    name?: string;
+    description?: string;
+    github?: string;
+    image?: string;
+    type: string;
+    readMoreLink?: string;
+    longDescription?: string;
+    teamMembers?: string[];
+    tools?: string[];
+    year?: string | number;
+  };
+
+  const projects: Project[] = (projectsData as RawProject[]).map((project) => ({
     title: project.name || "Untitled Project",
     description: project.description || "No description available.",
     github: project.github || undefined,
@@ -39,6 +51,10 @@ export default function ProjectsPage() {
     imageAltText: project.name || "Project Image",
     type: projectTypeMap[project.type] ?? ProjectType.genai,
     readMoreLink: project.readMoreLink || "#",
+    longDescription: project.longDescription,
+    teamMembers: project.teamMembers,
+    tools: project.tools,
+    year: project.year,
   }));
 
   const gradientClassMap: Record<ProjectType, string> = {
@@ -143,63 +159,14 @@ export default function ProjectsPage() {
                   filteredProjects.length % 2 === 1 &&
                   index === filteredProjects.length - 1;
               return (
-                  <a
+                  <div
                       key={index}
-                      href={card.github || card.readMoreLink}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={`
-                relative w-full max-w-[360px] mx-auto
-                rounded-[13px] p-3 sm:p-6 md:p-8 bg-white border border-gray-200 overflow-hidden
-                flex flex-col
-                transition-transform duration-300 ease-in-out
-                hover:-translate-y-1 hover:shadow-lg cursor-pointer
-                  no-underline justify-self-center md:justify-self-auto
-                ${isLastOddForTwoCols ? "md:col-span-2 lg:col-span-1" : ""}
-              `}
+                      className={`w-full flex justify-center md:justify-stretch ${
+                        isLastOddForTwoCols ? "md:col-span-2 lg:col-span-1" : ""
+                      }`}
                   >
-                    <div className="mb-2 sm:mb-4 rounded-lg overflow-hidden">
-                      <Image
-                          src={`/project_images/${encodeURIComponent(
-                              card.title
-                          )}.png`}
-                          alt={card.title}
-                          width={400}
-                          height={200}
-                          style={{objectFit: "cover"}}
-                          className="w-full aspect-[16/9] object-cover rounded-lg"
-                      />
-                    </div>
-                    <div className="mt-0">
-                      <h2
-                          className="font-bold font-sans leading-5 text-sm sm:text-base md:text-lg"
-                          style={{color: "var(--foreground)"}}
-                      >
-                        {card.title}
-                      </h2>
-                      <p
-                          className="font-sans font-normal text-xs sm:text-sm md:text-base leading-5 line-clamp-3 sm:line-clamp-3 md:line-clamp-4"
-                          style={{color: "var(--muted-foreground)"}}
-                      >
-                        {card.description}
-                      </p>
-                    </div>
-                    {card.github && (
-                        <div
-                            className="mt-2 hidden sm:inline-flex items-center gap-4 no-underline font-sans font-medium text-xs sm:text-sm"
-                            style={{color: "var(--foreground)"}}
-                        >
-                          <Image
-                              src={githubIcon}
-                              alt="GitHub Icon"
-                              width={20}
-                              height={20}
-                              className="w-4 h-4 sm:w-5 sm:h-5"
-                          />
-                          <span className="hidden sm:inline">Read More</span>
-                        </div>
-                    )}
-                  </a>
+                    <ProjectCard {...card} />
+                  </div>
               );
             })}
           </div>

--- a/client/src/components/cards/project-card.tsx
+++ b/client/src/components/cards/project-card.tsx
@@ -1,52 +1,64 @@
+"use client";
+
+import { useState } from "react";
 import Image from "next/image";
 import githubIcon from "../../assets/logos/github.svg";
 import { Project } from "@/types/projects";
+import ProjectModal from "@/components/projects/project-modal";
 
-const ProjectCard: React.FC<Project> = ({
-  title,
-  description,
-  github,
-  readMoreLink,
-  imageAltText = "Project Image",
-}) => {
+const ProjectCard: React.FC<Project> = (project) => {
+  const {
+    title,
+    description,
+    github,
+    imageAltText = "Project Image",
+  } = project;
+  const [open, setOpen] = useState(false);
+
   return (
-    <a
-      href={github || readMoreLink}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="relative w-full max-w-[360px] rounded-[13px] p-3 sm:p-6 md:p-8 bg-[var(--card)] border border-[var(--border)] overflow-hidden flex flex-col transition-transform duration-300 ease-in-out hover:-translate-y-1 hover:shadow-lg cursor-pointer mx-5 no-underline"
-    >
-      <div className="mb-2 sm:mb-4 rounded-lg overflow-hidden">
-        <Image
-          src={`/project_images/${encodeURIComponent(title)}.png`}
-          alt={imageAltText}
-          width={400}
-          height={200}
-          style={{ objectFit: "cover" }}
-          className="w-full aspect-[16/9] object-cover rounded-lg"
-        />
-      </div>
-      <div>
-        <h2 className="font-bold font-sans mt-1 mb-1 leading-5 text-[var(--card-foreground)] text-sm sm:text-base md:text-xl">
-          {title}
-        </h2>
-        <p className="text-[var(--muted-foreground)] font-sans font-normal text-xs sm:text-sm md:text-base leading-5 overflow-hidden line-clamp-3 sm:line-clamp-3 md:line-clamp-4">
-          {description}
-        </p>
-      </div>
-      {github && (
-        <div className="hidden sm:inline-flex items-center gap-2 text-[var(--foreground)] no-underline font-sans font-medium text-xs sm:text-sm mt-2">
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-haspopup="dialog"
+        className="relative w-full max-w-[360px] rounded-[13px] p-3 sm:p-6 md:p-8 bg-[var(--card)] border border-[var(--border)] overflow-hidden flex flex-col text-left transition-transform duration-300 ease-in-out hover:-translate-y-1 hover:shadow-lg cursor-pointer"
+      >
+        <div className="mb-2 sm:mb-4 rounded-lg overflow-hidden w-full">
           <Image
-            src={githubIcon}
-            alt="GitHub Icon"
-            width={20}
-            height={20}
-            className="w-4 h-4 sm:w-5 sm:h-5"
+            src={`/project_images/${encodeURIComponent(title)}.png`}
+            alt={imageAltText}
+            width={400}
+            height={200}
+            style={{ objectFit: "cover" }}
+            className="w-full aspect-[16/9] object-cover rounded-lg"
           />
-          <span className="hidden sm:inline">Read More</span>
         </div>
+        <div>
+          <h2 className="font-bold font-sans mt-1 mb-1 leading-5 text-[var(--card-foreground)] text-sm sm:text-base md:text-xl">
+            {title}
+          </h2>
+          <p className="text-[var(--muted-foreground)] font-sans font-normal text-xs sm:text-sm md:text-base leading-5 overflow-hidden line-clamp-3 sm:line-clamp-3 md:line-clamp-4">
+            {description}
+          </p>
+        </div>
+        <div className="hidden sm:inline-flex items-center gap-2 text-[var(--foreground)] font-sans font-medium text-xs sm:text-sm mt-2">
+          {github && (
+            <Image
+              src={githubIcon}
+              alt=""
+              width={20}
+              height={20}
+              className="w-4 h-4 sm:w-5 sm:h-5"
+            />
+          )}
+          <span>Read More</span>
+        </div>
+      </button>
+
+      {open && (
+        <ProjectModal project={project} onClose={() => setOpen(false)} />
       )}
-    </a>
+    </>
   );
 };
 

--- a/client/src/components/projects/project-modal.tsx
+++ b/client/src/components/projects/project-modal.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import Image from "next/image";
+import { X } from "lucide-react";
+import githubIcon from "@/assets/logos/github.svg";
+import { Project } from "@/types/projects";
+
+interface ProjectModalProps {
+  project: Project | null;
+  onClose: () => void;
+}
+
+const ProjectModal: React.FC<ProjectModalProps> = ({ project, onClose }) => {
+  useEffect(() => {
+    if (!project) return;
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [project, onClose]);
+
+  if (!project || typeof document === "undefined") return null;
+
+  const {
+    title,
+    description,
+    longDescription,
+    github,
+    readMoreLink,
+    imageAltText = title,
+    teamMembers,
+    tools,
+    year,
+  } = project;
+
+  const externalLink = readMoreLink && readMoreLink !== "#" ? readMoreLink : undefined;
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${title} details`}
+      onClick={onClose}
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4 py-8 overflow-y-auto"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="relative w-full max-w-2xl bg-[var(--card)] text-[var(--card-foreground)] rounded-[15px] border border-[var(--border)] shadow-2xl overflow-hidden my-auto"
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close project details"
+          className="absolute top-3 right-3 z-10 rounded-full p-2 bg-[var(--background)]/80 text-[var(--foreground)] border border-[var(--border)] hover:bg-[var(--accent)] transition-colors"
+        >
+          <X className="w-5 h-5" />
+        </button>
+
+        <div className="relative w-full aspect-[16/9] bg-[var(--muted)]">
+          <Image
+            src={`/project_images/${encodeURIComponent(title)}.png`}
+            alt={imageAltText}
+            fill
+            sizes="(max-width: 768px) 100vw, 672px"
+            style={{ objectFit: "cover" }}
+          />
+        </div>
+
+        <div className="p-6 sm:p-8 space-y-5">
+          <div>
+            <h2 className="font-sans font-bold text-2xl sm:text-3xl leading-tight">
+              {title}
+            </h2>
+            {year && (
+              <p className="mt-1 text-sm text-[var(--muted-foreground)]">{year}</p>
+            )}
+          </div>
+
+          <p className="font-sans text-sm sm:text-base text-[var(--muted-foreground)] whitespace-pre-line">
+            {longDescription || description}
+          </p>
+
+          {teamMembers && teamMembers.length > 0 && (
+            <div>
+              <h3 className="font-sans font-semibold text-sm uppercase tracking-wide text-[var(--foreground)] mb-2">
+                Team
+              </h3>
+              <p className="font-sans text-sm text-[var(--muted-foreground)]">
+                {teamMembers.join(", ")}
+              </p>
+            </div>
+          )}
+
+          {tools && tools.length > 0 && (
+            <div>
+              <h3 className="font-sans font-semibold text-sm uppercase tracking-wide text-[var(--foreground)] mb-2">
+                Tools & Frameworks
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {tools.map((tool) => (
+                  <span
+                    key={tool}
+                    className="inline-block rounded-full border border-[var(--border)] bg-[var(--background)] px-3 py-1 text-xs font-medium text-[var(--foreground)]"
+                  >
+                    {tool}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {(github || externalLink) && (
+            <div className="flex flex-wrap gap-3 pt-2">
+              {github && (
+                <a
+                  href={github}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--foreground)] text-[var(--background)] px-4 py-2 text-sm font-medium no-underline hover:opacity-90 transition-opacity"
+                >
+                  <Image
+                    src={githubIcon}
+                    alt=""
+                    width={18}
+                    height={18}
+                    className="invert"
+                  />
+                  View on GitHub
+                </a>
+              )}
+              {externalLink && (
+                <a
+                  href={externalLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center rounded-full border border-[var(--border)] px-4 py-2 text-sm font-medium text-[var(--foreground)] no-underline hover:bg-[var(--accent)] transition-colors"
+                >
+                  Learn more
+                </a>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default ProjectModal;

--- a/client/src/types/projects.ts
+++ b/client/src/types/projects.ts
@@ -18,4 +18,8 @@ export interface Project {
   imageAltText?: string;
   type: ProjectType;
   readMoreLink: string;
+  longDescription?: string;
+  teamMembers?: string[];
+  tools?: string[];
+  year?: string | number;
 }


### PR DESCRIPTION
Fixes #227

Replaces the "Read More" external link on project cards with an in-page modal showing the full description plus optional team, tools, and year metadata. Adds a portal-based ProjectModal (ESC / click out of modal / X to close) and refactors the projects-page grid to reuse <ProjectCard /> so carousel and grid share one trigger. The extended information needs to be manually added in a future PR. Below are screenshots of what it looks like with populated (fabricated) data. (This data is not commited).
<img width="1467" height="772" alt="image" src="https://github.com/user-attachments/assets/e2e46c1a-75cd-456a-8fa0-20eeff98365e" />
<img width="1465" height="782" alt="image" src="https://github.com/user-attachments/assets/6486c3be-1517-4e55-a974-d509e198edd0" />
<img width="1468" height="790" alt="image" src="https://github.com/user-attachments/assets/d6eeab06-19dc-4d79-b642-1183c1e9cab4" />
