### PR TITLE
feat: github action to label by PR size

### DIFF
--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -1,0 +1,57 @@
+name: Label PR size
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+  issues: write
+
+jobs:
+  label-size:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Label PR size
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const changed = pr.additions + pr.deletions;
+
+            const labels = [
+              { name: "size/xs", max: 10 },
+              { name: "size/s", max: 50 },
+              { name: "size/m", max: 200 },
+              { name: "size/l", max: 500 },
+              { name: "size/xl", max: Infinity },
+            ];
+
+            const sizeLabels = labels.map(label => label.name);
+            const newLabel = labels.find(label => changed <= label.max).name;
+
+            const { owner, repo } = context.repo;
+            const issue_number = pr.number;
+
+            const currentLabels = pr.labels.map(label => label.name);
+
+            for (const label of sizeLabels) {
+              if (currentLabels.includes(label) && label !== newLabel) {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number,
+                  name: label,
+                });
+              }
+            }
+
+            if (!currentLabels.includes(newLabel)) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number,
+                labels: [newLabel],
+              });
+            }


### PR DESCRIPTION
Adds a GitHub Action that automatically labels pull requests based on total lines changed.

- Runs when a pull request is opened, updated, or reopened
- Computes PR size using additions + deletions
- Removes any previous `size/*` label
- Applies one of:
  - `size/xs`: 0–10 lines
  - `size/s`: 11–50 lines
  - `size/m`: 51–200 lines
  - `size/l`: 201–500 lines
  - `size/xl`: 500+ lines

Fixes #118 