### PR TITLE
docs: replace the setup path with one that works

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+<!--
+Thanks for contributing! A filled-in description gets your PR reviewed faster.
+See CONTRIBUTING.md if this is your first one.
+-->
+
+## What changed
+
+<!-- A short summary of the change. -->
+
+## Why
+
+<!-- The problem this solves. If the reasoning is non-obvious, this is the most
+     useful part of the PR — the diff already shows what changed. -->
+
+Closes #
+
+## Screenshots
+
+<!-- Required for any visual change. Before/after side by side if you can.
+     Include mobile if the layout is responsive. Delete this section if the
+     change has no UI. -->
+
+## How to test
+
+<!-- Steps for a reviewer to verify this locally. -->
+
+1.
+
+## Checklist
+
+- [ ] `npm run lint` passes
+- [ ] `npm run typecheck` passes
+- [ ] `npm test` passes
+- [ ] Tests added or updated for this change
+- [ ] Any new environment variable is documented in `client/env.example` and added to GitHub Actions secrets + Vercel
+- [ ] Any surface exposing applicant data is behind `requireAdmin()` / `getAdminUser()`
+- [ ] Docs under `docs/client/` updated for any new page or component
+
+## Notes for reviewers
+
+<!-- Anything worth flagging: a tradeoff you made, something you were unsure
+     about, an area that deserves a closer look, or a follow-up you plan to do
+     separately. Optional. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,148 @@
+# Contributing
+
+Welcome to the UTMIST website team. This page covers how work gets from an issue
+to `main`.
+
+New here? Start with [docs/Setup.md](docs/Setup.md) and get the site running
+locally first — everything below assumes you have it up.
+
+## Picking something to work on
+
+All work starts from an [issue](https://github.com/UTMIST/UTMIST/issues).
+
+- **First contribution?** Filter by
+  [`good first issue`](https://github.com/UTMIST/UTMIST/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+  These are scoped so you can finish them without deep context on the codebase.
+- Issues are prioritized `P0` (highest) through `P3`. If you have no preference,
+  take the highest-priority thing that is unassigned.
+- **Comment on the issue to claim it**, and it will be assigned to you. This
+  stops two people building the same thing — which has happened here before.
+- If nothing fits, open an issue with the
+  [bug](.github/ISSUE_TEMPLATE/bug_report.md) or
+  [feature](.github/ISSUE_TEMPLATE/feature_request.md) template and say you would
+  like to take it.
+
+If you get stuck or go quiet on an issue, say so in a comment and unassign
+yourself. Stalled-but-assigned issues are worse than open ones.
+
+## Branches
+
+Branch off the latest `main`:
+
+```bash
+git checkout main
+git pull
+git checkout -b feat/142-add-events-filter
+```
+
+Name branches `type/issue-number-short-description`, using the same types as
+commits below. The issue number is what lets a reviewer find the context.
+
+Never commit directly to `main` — it deploys to production on every push.
+
+## Commits
+
+Write [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type: short summary in the imperative mood
+```
+
+| Type | For |
+| --- | --- |
+| `feat` | A new user-facing capability |
+| `fix` | A bug fix |
+| `docs` | Documentation only |
+| `style` | Formatting, no behaviour change |
+| `refactor` | Restructuring with no behaviour change |
+| `test` | Adding or fixing tests |
+| `chore` | Tooling, CI, dependencies |
+
+```
+feat: add department filter to events page
+fix: prevent duplicate resume upload on double submit
+chore: bump next to 16.0.8
+```
+
+If the change needs explaining, add a body after a blank line and say **why**,
+not just what. The diff already shows what changed; it cannot show what you were
+working around or what you ruled out.
+
+## Before you push
+
+Run the same three checks CI gates on:
+
+```bash
+cd client
+npm run lint && npm run typecheck && npm test
+```
+
+All three must pass. If lint reports something it can fix itself, `npm run
+lint:fix` will handle it.
+
+Add tests for behaviour you add or fix — see
+[docs/client/Testing.md](docs/client/Testing.md), which includes a template and
+cookbooks for the common cases (mocking Supabase, `next/navigation`, async server
+components).
+
+## Pull requests
+
+Push your branch and open a PR against `main`. Fill in the template: what
+changed, why, the issue it closes, and screenshots for anything visual.
+
+- **Link the issue** with `Closes #142` so it closes on merge.
+- **Keep PRs small.** A `size/xs` or `size/s` label gets reviewed in a day;
+  `size/xl` can sit for weeks. The label is applied automatically. If a change is
+  genuinely large, say so in the description and explain how to read it.
+- **Mark it draft** if it is not ready — a draft PR is a good way to get early
+  feedback without asking anyone to do a full review.
+
+### What CI checks
+
+Every PR runs [`.github/workflows/ci.yml`](.github/workflows/ci.yml):
+
+| Step | Fails when |
+| --- | --- |
+| Lint | ESLint reports an error (warnings do not fail the build) |
+| Typecheck | TypeScript reports an error |
+| Test | Any Jest test fails |
+| Build | `next build` fails — often a missing env var or a prerender error |
+
+A merge to `main` deploys to production, so a green build is the last gate before
+users see it.
+
+### Review
+
+A maintainer reviews and either approves or requests changes. Push follow-up
+commits to the same branch; do not force-push once review has started, as it
+makes review comments hard to follow.
+
+Receiving review: it is fine to push back. If a suggestion seems wrong, say so
+and explain why — that conversation is the point. Do not silently apply a change
+you believe is incorrect.
+
+Once approved, a maintainer merges. Delete your branch afterward.
+
+## Code conventions
+
+Match the surrounding code. Beyond that:
+
+- **TypeScript** throughout. `strict` is on; avoid `any`.
+- **Tailwind** for styling. Reuse existing tokens and gradient utilities rather
+  than adding new one-off colors — see [docs/client/styles/](docs/client/styles/).
+- **Path alias:** import from `@/` (mapped to `client/src/`) rather than long
+  relative chains.
+- **Access control:** any surface exposing applicant data must sit behind
+  `requireAdmin()` or `getAdminUser()`. See
+  [client/README.md](client/README.md#two-layers-of-protection) — middleware
+  alone is not enough.
+- **Environment variables:** document every new one in
+  [`client/env.example`](client/env.example), and add it to both GitHub Actions
+  secrets and the Vercel project settings.
+- **Documentation:** if you add a page or component, add a matching note under
+  [docs/client/](docs/client/).
+
+## Questions
+
+Ask in the team channel, or comment on the issue you are working on. A question
+asked early is much cheaper than a PR built on a wrong assumption.

--- a/README.md
+++ b/README.md
@@ -49,16 +49,12 @@ Please refer to [Development Environment Setup Documentation](docs/Setup.md).
 <!-- CONTRIBUTING -->
 ## Contributing
 
-Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how work goes from an issue to `main`
+— claiming an issue, branch and commit conventions, the checks to run before
+pushing, and what to expect from review.
 
-If you have a suggestion that would make this better, please fork the repo and create a pull request. You can also simply open an issue with the tag "enhancement".
-Don't forget to give the project a star! Thanks again!
-
-1. Fork the Project
-2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
-3. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
-4. Push to the Branch (`git push origin feature/AmazingFeature`)
-5. Open a Pull Request
+New contributors: start with [docs/Setup.md](docs/Setup.md), then pick up a
+[`good first issue`](https://github.com/UTMIST/UTMIST/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 <!-- LICENSE -->
 ## License

--- a/client/README.md
+++ b/client/README.md
@@ -1,231 +1,100 @@
 # UTMIST Client Application
 
-A modern React/Next.js application with secure authentication using Supabase Auth, built for the University of Toronto Machine Intelligence Student Team (UTMIST).
+The UTMIST club website: a Next.js 16 app (App Router, React 19, Tailwind 4)
+with authentication and data storage on Supabase.
 
-## 🚀 Features
+This document covers **how the app is put together**. For anything else:
 
-- **Secure Authentication**: Email/password authentication with Supabase
-- **Protected Routes**: Middleware-based route protection
-- **Session Management**: Server-side session handling with cookies
-- **Email Confirmation**: Support for email verification flows
-- **Profile Management**: User profile creation and updates
-- **Responsive Design**: Mobile-first design with Tailwind CSS
+| You want to… | Go to |
+| --- | --- |
+| Get it running locally | [docs/Setup.md](../docs/Setup.md) |
+| Open your first PR | [CONTRIBUTING.md](../CONTRIBUTING.md) |
+| Write or run tests | [docs/client/Testing.md](../docs/client/Testing.md) |
+| Find where a file lives | [docs/client/FileStructure.md](../docs/client/FileStructure.md) |
+| Read up on a specific page or component | [docs/client/](../docs/client/) |
 
-## 📋 Prerequisites
+## Authentication
 
-- Node.js 18+ and npm
-- A Supabase account and project
+Email/password auth through Supabase, with sessions carried in server-side
+cookies.
 
-## 🛠️ Setup Instructions
+### Sign-in flow
 
-### 1. Clone and Install Dependencies
+1. The user submits credentials on `/auth`.
+2. The client calls the Supabase Auth API.
+3. On success the session is established and cookies are set via
+   `/api/auth/set-cookie`.
+4. Middleware refreshes that session on subsequent requests.
 
-```bash
-git clone <repository-url>
-cd client
-npm install
+Profile data lives in a `user` table keyed by the Supabase auth user id. The
+`admin` boolean on that row is what distinguishes an admin from a member.
+
+### Two layers of protection
+
+Both layers matter, and neither is sufficient alone.
+
+**1. Middleware** ([`src/middleware.ts`](src/middleware.ts) →
+[`src/utils/supabase/middleware.ts`](src/utils/supabase/middleware.ts))
+
+Runs on every non-asset request. It refreshes the Supabase session and bounces
+signed-out users away from anything under `USER_PATHS`:
+
+```
+/dashboard   /api   /admin   /applicants
 ```
 
-### 2. Supabase Configuration
+Middleware only knows *signed in* versus *signed out*. It cannot tell an admin
+from an ordinary member.
 
-#### Create Supabase Project
-1. Go to [supabase.com](https://supabase.com) and create an account
-2. Create a new project
-3. Wait for the project to be ready (this can take a few minutes)
+**2. Server-side guards** ([`src/lib/auth/guards.ts`](src/lib/auth/guards.ts))
 
-#### Configure Authentication
-1. In your Supabase dashboard, go to **Authentication > Settings**
-2. Configure the following settings:
-   - **Enable email confirmations**: Toggle ON if you want users to confirm their email
-   - **Site URL**: Set to `http://localhost:3000` for development
-   - **Redirect URLs**: Add `http://localhost:3000/auth/callback`
+This is where the admin check actually happens.
 
-#### Get Supabase Keys
-1. Go to **Settings > API** in your Supabase dashboard
-2. Copy the following values:
-   - **Project URL** (looks like: `https://xxxxx.supabase.co`)
-   - **Anon key** (starts with `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...`)
+| Guard | Use in | Behaviour |
+| --- | --- | --- |
+| `requireUser()` | Server components | Returns the profile, redirects to `/auth` if signed out |
+| `requireAdmin()` | Server components | Returns the profile, redirects to `/auth` unless `admin` |
+| `getCurrentUser()` | Route handlers | Returns the profile or `null` |
+| `getAdminUser()` | Route handlers | Returns the profile, or `null` unless `admin` |
 
-### 3. Environment Variables
+> **Any surface exposing applicant data — names, emails, phone numbers,
+> addresses, resumes, essay answers — must sit behind `requireAdmin()` in a
+> server component, or `getAdminUser()` in a route handler.** Adding the path to
+> `USER_PATHS` is not enough on its own; that only gates signed-out visitors.
 
-Create a `.env.local` file in the client directory:
+A page that calls a guard becomes dynamically rendered rather than statically
+prerendered. You can confirm a route is actually gated by looking for `ƒ`
+(Dynamic) rather than `○` (Static) next to it in `npm run build` output.
 
-```bash
-# Supabase Configuration
-NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+### Error handling
 
-# Optional: Add these for additional features
-NEXT_PUBLIC_SITE_URL=http://localhost:3000
-```
+Auth errors are normalized to the `AUTH_ERRORS` codes in
+[`src/utils/auth.ts`](src/utils/auth.ts), so the UI can distinguish cases like
+"email already taken" from "email needs confirmation" and offer the right
+follow-up (such as resending a confirmation mail).
 
-**⚠️ Important Notes:**
-- Replace `your_supabase_project_url` with your actual Supabase project URL
-- Replace `your_supabase_anon_key` with your actual Supabase anon key
-- Never commit the `.env.local` file to version control
-- For production, set these environment variables in your deployment platform
+## Server-side logic
 
-### 4. Database Schema (Automatic)
+There is no separate backend service. Server work lives in App Router route
+handlers under [`src/app/api/`](src/app/api/):
 
-The authentication system uses Supabase Auth's built-in user table. User profile data is stored in the `auth.users` metadata field, so no additional database setup is required.
+| Route | Purpose |
+| --- | --- |
+| `api/auth/set-cookie` | Establishes the session cookie after sign-in |
+| `api/auth/signout` | Clears the session |
+| `api/applications` | Applicant records — admin only |
+| `api/drive_upload` | Pushes uploaded resumes to Google Drive |
+| `api/umami/overview` | Traffic stats for the `/admin` dashboard |
 
-## 🚦 Running the Application
+## Deployment
 
-### Development
-```bash
-npm run dev
-```
+Vercel, driven by [`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
+Every push to `main` that passes lint, typecheck, test, and build is deployed to
+production automatically.
 
-The application will be available at `http://localhost:3000`
+Environment variables are stored as GitHub Actions secrets for CI and in the
+Vercel project settings for runtime. When adding a new one, it must be added in
+**both** places, plus documented in [`env.example`](env.example).
 
-### Production Build
-```bash
-npm run build
-npm start
-```
-
-## 🔐 Authentication Features
-
-### Sign Up/Login Page (`/auth`)
-- Email and password authentication
-- Client-side form validation
-- Password strength requirements
-- Email confirmation support
-- Error handling with user-friendly messages
-
-### Protected Routes
-- `/dashboard` - User dashboard (requires authentication)
-- Automatic redirection for unauthenticated users
-- Session-based protection via middleware
-
-### Session Management
-- Server-side session cookies
-- Automatic session refresh
-- Secure logout with session cleanup
-
-## 🎨 User Interface
-
-### Features
-- Responsive design optimized for mobile and desktop
-- Clean, modern interface with Tailwind CSS
-- Form validation with real-time feedback
-- Loading states and error messages
-- Accessibility features
-
-### Key Components
-- `AuthPage` - Combined login/register form
-- `Dashboard` - Protected user dashboard
-- Protected route middleware
-- Authentication utilities
-
-## 🔧 Technical Architecture
-
-### Authentication Flow
-1. User submits credentials via form
-2. Client calls Supabase Auth API
-3. On success, session is established
-4. Server-side cookies are set via API route
-5. Middleware protects subsequent requests
-
-### Error Handling
-- Standardized error codes (`AUTH_ERRORS`)
-- Specific error messages for different scenarios
-- Email confirmation resend functionality
-- User-friendly error display
-
-### File Structure
-```
-client/src/
-├── app/
-│   ├── auth/
-│   │   ├── page.tsx          # Authentication page
-│   │   └── callback/
-│   │       └── route.ts      # OAuth callback handler
-│   ├── dashboard/
-│   │   └── page.tsx          # Protected dashboard
-│   └── api/
-│       └── auth/
-│           ├── set-cookie/   # Session management
-│           └── signout/      # Logout handling
-├── utils/
-│   └── auth.ts               # Authentication utilities
-├── types/
-│   └── auth.ts               # TypeScript types
-├── lib/
-│   └── supabase.ts           # Supabase client config
-└── middleware.ts             # Route protection
-```
-
-## 🧪 Testing
-
-### Current Status
-- ✅ Authentication utilities implemented
-- ✅ Protected routes working
-- ✅ Session management functional
-- ❌ Unit tests for form validation (not implemented)
-- ❌ Integration tests for auth flow (not implemented)
-
-### Adding Tests
-To fulfill the testing requirements, you can add:
-
-```bash
-# Install testing dependencies
-npm install --save-dev @testing-library/react @testing-library/jest-dom jest jest-environment-jsdom
-
-# Create test files
-touch src/utils/__tests__/auth.test.ts
-touch src/app/auth/__tests__/page.test.tsx
-```
-
-## 🚀 Deployment
-
-### Vercel (Recommended)
-1. Connect your GitHub repository to Vercel
-2. Add environment variables in Vercel dashboard
-3. Update Supabase redirect URLs to include your production domain
-
-### Other Platforms
-- Ensure environment variables are set
-- Update Supabase configuration for production URLs
-- Configure proper redirect URLs in Supabase dashboard
-
-## 🐛 Troubleshooting
-
-### Common Issues
-
-**"Missing Supabase environment variables"**
-- Ensure `.env.local` file exists and contains correct values
-- Restart development server after adding environment variables
-
-**Email confirmation not working**
-- Check if email confirmation is enabled in Supabase
-- Verify email templates are configured
-- Check spam folder for confirmation emails
-
-**Session not persisting**
-- Ensure middleware is configured correctly
-- Check that cookies are being set properly
-- Verify Supabase client configuration
-
-### Getting Help
-- Check Supabase documentation: https://supabase.com/docs
-- Review Next.js authentication patterns
-- Check browser network tab for API errors
-
-## 📚 Additional Resources
-
-- [Supabase Auth Documentation](https://supabase.com/docs/guides/auth)
-- [Next.js Authentication](https://nextjs.org/docs/authentication)
-- [Tailwind CSS Documentation](https://tailwindcss.com/docs)
-
-## 🤝 Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Add tests if applicable
-5. Submit a pull request
-
-## 📄 License
-
-This project is licensed under the MIT License - see the LICENSE file for details.
+Supabase redirect URLs need to list the production origin alongside
+`http://localhost:3000`, or auth callbacks will fail in production only.

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -1,66 +1,141 @@
 # Development Environment Setup
 
+This is the only setup guide you need. If you get through it and `npm run dev`
+serves the site at `http://localhost:3000`, you are ready to pick up an issue —
+see [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+The site is a single full-stack Next.js app living in `client/`. Server-side
+logic is in route handlers under `client/src/app/api/`. There is no separate
+backend service to run.
+
 ## Prerequisites
-### Operating System 
-> UNIX based systems (e.g. macOS and Linux Distributions) can proceed to next prerequisites.
 
-Developers on Windows are encouraged to install Window Subsystem for Linux (WSL) for development because it is easier to work with the UNIX terminals and package management. 
+### Node.js 22
 
-- If developer is interested in using WSL, please refer to [Microsoft's WSL installation guide](https://learn.microsoft.com/en-us/windows/wsl/install).
-  
-  - It is recommended to use <b>Ubuntu 20.04</b> for the Linux Distribution
-- If developer is NOT interested in using WSL, please for the appropriate setup instructions found on official documentations on the tools and libraries the codebase uses.
+The project is pinned to **Node 22**. Older versions fail in ways that do not
+name the real cause — Next 16 refuses to start, and Jest crashes inside its own
+config loader. `npm install` will stop you before you get that far.
 
-<b>Note</b>: The documentation's setup instructions are written for UNIX development environments.
+The version is pinned in [`client/.nvmrc`](../client/.nvmrc) and
+[`client/.tool-versions`](../client/.tool-versions), so a version manager will
+pick it up automatically:
 
-
-### Package Manager
-
-The project uses `npm` as the package manager for managing dependencies and scripts. Ensure you have `Node.js` installed on your system, as it includes `npm` by default. You can download and install the latest LTS version of Node.js from [Node.js official website](https://nodejs.org/).
-
-To verify the installation, run the following commands:
-```bash
-node -v
-npm -v
-```
-This will display the installed versions of Node.js and npm, respectively.
-
-## Install Dependencies
-### Client
 ```bash
 cd client
+
+nvm use          # nvm — reads .nvmrc, add `nvm install` first time
+mise install     # mise — reads .tool-versions
+asdf install     # asdf — reads .tool-versions
+```
+
+No version manager? Install Node 22 LTS from
+[nodejs.org](https://nodejs.org/). Then confirm:
+
+```bash
+node -v          # must print v22.x
+```
+
+### Operating system
+
+macOS and Linux work directly.
+
+On Windows, use **Windows Subsystem for Linux** — the tooling here assumes a
+UNIX shell, and every command in this guide is written for one. See
+[Microsoft's WSL installation guide](https://learn.microsoft.com/en-us/windows/wsl/install);
+Ubuntu 22.04 or newer is a good default.
+
+## Setup
+
+### 1. Clone and install
+
+```bash
+git clone https://github.com/UTMIST/UTMIST.git
+cd UTMIST/client
 npm install
 ```
 
-### Server
-```
-cd server
-bash setup.bash
+### 2. Configure environment variables
+
+The app reads its configuration from `client/.env`. Copy the template:
+
+```bash
+cp env.example .env
 ```
 
-## Running the Application
-### Client
-#### Development Mode
+Then fill in the values. [`client/env.example`](../client/env.example) documents
+each one and marks which are required — the app will not boot without the
+Supabase pair, and `npm run build` fails without the Google Maps key.
+
+**You will not be able to fill these in on your own.** Ask a web team lead for
+access to the shared credentials.
+
+`.env` is gitignored. Never commit it.
+
+### 3. Run it
+
 ```bash
 npm run dev
 ```
 
-#### Production Mode
+The site is served at `http://localhost:3000`.
+
+## Everyday commands
+
+Run these from `client/`:
+
+| Command | What it does |
+| --- | --- |
+| `npm run dev` | Development server with hot reload |
+| `npm run build` | Production build |
+| `npm start` | Serve a production build (run `build` first) |
+| `npm run lint` | ESLint |
+| `npm run lint:fix` | ESLint, fixing what it can automatically |
+| `npm run typecheck` | Generate Next route types, then typecheck |
+| `npm test` | Full Jest suite |
+| `npm run test:watch` | Jest, re-running on change |
+
+Before pushing, run the three checks CI gates on:
+
 ```bash
-npm run build
-npm start
+npm run lint && npm run typecheck && npm test
 ```
 
-### Server
-#### Development Mode
-```bash
-python3 manage.py runserver
-```
-
-#### Production Mode
-```bash
-gunicorn projectname.wsgi:application --bind 0.0.0.0:8000
-```
+See [docs/client/Testing.md](client/Testing.md) for how the test suite is
+organized and how to add tests.
 
 ## Troubleshooting
-- For issues related to getting WSL running, please refer to [Microsoft WSL's troubleshooting guide](https://learn.microsoft.com/en-us/windows/wsl/troubleshooting).
+
+**`npm ERR! code EBADENGINE` … `Required: {"node":">=22.0.0"}`**
+
+You are on the wrong Node version. This is the error working correctly — it is
+telling you up front instead of letting Next or Jest fail confusingly later.
+Switch to Node 22 (see [Prerequisites](#nodejs-22)) and re-run.
+
+**`Missing Supabase environment variables. Please check your .env file.`**
+
+`client/.env` is missing or incomplete. See
+[step 2](#2-configure-environment-variables). Restart the dev server after
+editing it — Next only reads env files at startup.
+
+**`Google Maps API key is not defined`**
+
+`NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` is unset. Only `/eigenai` breaks under
+`npm run dev`, but `npm run build` fails outright because the page is
+prerendered.
+
+**`tsc` reports errors for every image import**
+
+Run `npm run typecheck` rather than `tsc --noEmit` directly. The type
+declarations for image imports live in `next-env.d.ts`, which Next generates and
+git ignores; the `typecheck` script runs `next typegen` first to produce it.
+
+**WSL problems**
+
+See [Microsoft's WSL troubleshooting guide](https://learn.microsoft.com/en-us/windows/wsl/troubleshooting).
+
+## Where to go next
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — branching, commits, PRs, picking an issue
+- [docs/FileStructure.md](FileStructure.md) — how the repo is laid out
+- [docs/client/](client/) — per-page and per-component reference
+- [client/README.md](../client/README.md) — auth and architecture notes

--- a/docs/client/Testing.md
+++ b/docs/client/Testing.md
@@ -288,7 +288,11 @@ When in doubt, copy the closest existing test:
 
 ## CI
 
-Tests are intended to run in CI as part of the build. The recommended invocation is `npm test` (no watcher, exits non-zero on failure). For coverage thresholds, configure them under the `coverageThreshold` key in `jest.config.js`.
+[`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) runs `npm test` on every pull request, alongside lint and typecheck, before the build. A failing test blocks the merge.
+
+The suite needs no secrets in CI — it provisions its own environment. `jest.setup.js` sets the Supabase variables, and `tests/unit/pages/eigenai.test.tsx` sets and unsets `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` itself to cover both branches. Injecting those values through the workflow would break that test.
+
+For coverage thresholds, configure them under the `coverageThreshold` key in `jest.config.js`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
> **Stacked on #235.** Base is `chore/pin-node-and-gate-ci`, because these docs
> describe `npm run typecheck` and Node 22, which that PR introduces. Merge #235
> first and this retargets to `main` automatically.

## Why

A new contributor following our docs could not get the site running, and the docs disagreed with each other about how to try.

**`docs/Setup.md`** — where `README.md` sends everyone — described a backend that doesn't exist. It instructed `cd server`, `bash setup.bash`, `python3 manage.py runserver`, and gunicorn. There is no `server/` directory on `main`, and `docs/FileStructure.md` already says so. It also never mentioned copying `env.example`, without which the app doesn't boot at all.

**`client/README.md`** was a second, competing setup guide, stale in ways that actively mislead:

| Claim | Reality |
| --- | --- |
| "Node.js 18+" | Next 16 requires `>=20.9.0` and refuses to start |
| Unit + integration tests "❌ not implemented" | 25 suites, 153 tests |
| "npm install --save-dev jest …" | jest has been a devDependency for a while |
| `.env.local` with 3 Supabase vars | `env.example` documents ~15, and says `.env` |

**No `CONTRIBUTING.md`** existed at all.

## What changed

**`docs/Setup.md` — rewritten as the single setup path.** Node 22 via `.nvmrc`/`.tool-versions`, install, `cp env.example .env` with a pointer to ask a lead for credentials, run. Adds an everyday-command table, the three checks CI gates on, and troubleshooting for the errors newcomers actually hit: `EBADENGINE`, the Supabase env error, the Maps key, and the image-import type errors you get from running `tsc` directly instead of `npm run typecheck`.

**`client/README.md` — narrowed to architecture.** Setup/env/deployment duplication removed; kept and corrected the genuinely useful part. The auth section now reflects what landed in #234: middleware gates signed-out users on `USER_PATHS`, and the admin check lives in `requireAdmin`/`getAdminUser`, with the note that middleware alone is not sufficient. Includes the guard table and how to confirm a route is gated (`ƒ` vs `○` in build output).

**`CONTRIBUTING.md` — new.** Claiming an issue by commenting, branch and commit conventions, pre-push checks, PR expectations, what CI enforces, and review etiquette. Conventional Commits matches where recent history already trends.

**`.github/pull_request_template.md` — new.** Checklist covers the env-var and applicant-data rules specifically, since those are the two things easiest to get wrong here.

**Doc roles are now distinct**, rather than three files all claiming to be getting-started:

- root `README.md` → orientation + links
- `docs/Setup.md` → the only setup path
- `client/README.md` → architecture reference

## Verification

Every relative link in the touched files was checked to resolve (0 broken). Docs-only, so no behaviour change — CI on #235 already covers lint/typecheck/test/build.

## Note

The PR size labeler fix that was originally in this branch has moved to #237, so it can merge against `main` independently instead of waiting behind this stack. This PR is docs-only now.

The red `label-size` check here is that same pre-existing bug, unrelated to this PR — it clears once #237 is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
