### PR TITLE
fix: grant the PR size labeler permission to write labels

### DIFF
--- a/.github/workflows/pr-size-label.yml
+++ b/.github/workflows/pr-size-label.yml
@@ -4,8 +4,11 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+# Labels on a pull request are written through the issues endpoint, but the
+# permission GitHub checks is `pull-requests` — `issues: write` alone yields
+# "Resource not accessible by integration" (403) on the addLabels call.
 permissions:
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 jobs:


### PR DESCRIPTION
## Why

The `Label PR size` workflow has failed on **every** pull request since it was added in #232. It computes the correct label and then can't write it:

```
POST /repos/UTMIST/UTMIST/issues/235/labels  {"labels":["size/l"]}
→ 403 Resource not accessible by integration
```

Labels on a pull request are written through the *issues* endpoint, which is the misleading part — the permission GitHub actually checks is `pull-requests`, and it was set to `read`. The `issues: write` the workflow already had governs issue objects, not pull requests.

GitHub's [workflow-syntax docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions) give this exact case as the example for the scope:

> `pull-requests: write` permits an action to add a label to a pull request.

## What changed

```diff
 permissions:
-  pull-requests: read
+  pull-requests: write
   issues: write
```

Plus a comment recording why, so it doesn't get "tidied" back to `read`.

## How it went unnoticed

No PR was opened between #232 landing on `main` (Aug 7) and now, so the workflow had never actually run. Its entire history is two runs, both failures, both from the onboarding PRs (#235, #236):

```
$ gh run list --workflow=pr-size-label.yml
completed  failure  docs: replace the setup path...        31330152267
completed  failure  chore: pin Node 22, repair lint...     31329919683
```

It has never succeeded.

## Verification

⚠️ **This cannot be verified until it is on `main`.** `pull_request_target` loads the workflow from the *base* branch by design — that's what stops a fork PR from granting itself write permissions by editing its own workflow. So this PR will still be labeled by the broken copy, and its `label-size` check will still be red.

The first PR opened *after* this merges is the real check.

## Notes for reviewers

Split out of #236 so it can merge against `main` on its own rather than waiting behind the toolchain/docs stack.

`issues: write` is now arguably redundant — nothing here touches an issue. I kept it because `removeLabel` runs against the same endpoint and I couldn't test the narrower grant without merging first. Worth tightening once this is confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
